### PR TITLE
Add generators to API and add generator and 079 interaction events

### DIFF
--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -102,4 +102,29 @@ namespace Smod2.API
 		public abstract PocketDimensionExitType ExitType { get; set; }
 		public abstract Vector Position { get; }
 	}
+
+    public enum GeneratorType
+    {
+        EntranceCheckpoint = 0,
+        HCZArmory = 1,
+        ServerRoom = 2,
+        MicroHID = 3,
+        Nuke = 4,
+        SCP049 = 5,
+        SCP079 = 6,
+        SCP096 = 7,
+        SCP106 = 8,
+        SCP939 = 9
+    }
+
+    public abstract class Generator
+    {
+        public abstract bool Open { get; set; }
+        public abstract bool Locked { get; set; }
+        public abstract bool HasTablet { get; set; }
+        public abstract bool Engaged { get; set; }
+        public abstract GeneratorType Type { get; }
+        public abstract float TimeLeft { get; set; }
+        public abstract Vector Position { get; }
+    }
 }

--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -12,7 +12,7 @@ namespace Smod2.API
 		public abstract List<Door> GetDoors();
 		public abstract List<PocketDimensionExit> GetPocketDimensionExits();
 		public abstract Dictionary<Vector, Vector> GetElevatorTeleportPoints();
-		public abstract List<Generator> GetGenerators();
+		public abstract Generator[] GetGenerators();
 		public abstract void Shake();
 		public abstract bool WarheadDetonated { get; }
 		public abstract bool LCZDecontaminated { get; }

--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -106,16 +106,16 @@ namespace Smod2.API
 
     public enum GeneratorType
     {
-        EntranceCheckpoint = 0,
-        HCZArmory = 1,
-        ServerRoom = 2,
-        MicroHID = 3,
-        Nuke = 4,
-        SCP049 = 5,
-        SCP079 = 6,
-        SCP096 = 7,
-        SCP106 = 8,
-        SCP939 = 9
+        ENTRANCE_CHECKPOINT = 0,
+        HCZ_ARMORY = 1,
+        SERVER_ROOM = 2,
+        MICROHID = 3,
+        NUKE = 4,
+        SCP_049 = 5,
+        SCP_079 = 6,
+        SCP_096 = 7,
+        SCP_106 = 8,
+        SCP_939 = 9
     }
 
     public abstract class Generator

--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -12,7 +12,8 @@ namespace Smod2.API
 		public abstract List<Door> GetDoors();
 		public abstract List<PocketDimensionExit> GetPocketDimensionExits();
 		public abstract Dictionary<Vector, Vector> GetElevatorTeleportPoints();
-		public abstract void Shake();
+	    public abstract List<Generator> GetGenerators();
+        public abstract void Shake();
 		public abstract bool WarheadDetonated { get; }
 		public abstract bool LCZDecontaminated { get; }
 		public abstract void SpawnItem(ItemType type, Vector position, Vector rotation);

--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -12,8 +12,8 @@ namespace Smod2.API
 		public abstract List<Door> GetDoors();
 		public abstract List<PocketDimensionExit> GetPocketDimensionExits();
 		public abstract Dictionary<Vector, Vector> GetElevatorTeleportPoints();
-	    public abstract List<Generator> GetGenerators();
-        public abstract void Shake();
+		public abstract List<Generator> GetGenerators();
+		public abstract void Shake();
 		public abstract bool WarheadDetonated { get; }
 		public abstract bool LCZDecontaminated { get; }
 		public abstract void SpawnItem(ItemType type, Vector position, Vector rotation);
@@ -104,28 +104,28 @@ namespace Smod2.API
 		public abstract Vector Position { get; }
 	}
 
-    public enum GeneratorType
-    {
-        ENTRANCE_CHECKPOINT = 0,
-        HCZ_ARMORY = 1,
-        SERVER_ROOM = 2,
-        MICROHID = 3,
-        NUKE = 4,
-        SCP_049 = 5,
-        SCP_079 = 6,
-        SCP_096 = 7,
-        SCP_106 = 8,
-        SCP_939 = 9
-    }
+	public enum GeneratorType
+	{
+		ENTRANCE_CHECKPOINT = 0,
+		HCZ_ARMORY = 1,
+		SERVER_ROOM = 2,
+		MICROHID = 3,
+		NUKE = 4,
+		SCP_049 = 5,
+		SCP_079 = 6,
+		SCP_096 = 7,
+		SCP_106 = 8,
+		SCP_939 = 9
+	}
 
-    public abstract class Generator
-    {
-        public abstract bool Open { get; set; }
-        public abstract bool Locked { get; set; }
-        public abstract bool HasTablet { get; set; }
-        public abstract bool Engaged { get; set; }
-        public abstract GeneratorType Type { get; }
-        public abstract float TimeLeft { get; set; }
-        public abstract Vector Position { get; }
-    }
+	public abstract class Generator
+	{
+		public abstract bool Open { get; set; }
+		public abstract bool Locked { get; set; }
+		public abstract bool HasTablet { get; set; }
+		public abstract bool Engaged { get; set; }
+		public abstract GeneratorType Type { get; }
+		public abstract float TimeLeft { get; set; }
+		public abstract Vector Position { get; }
+	}
 }

--- a/Smod2/Smod2/EventSystem/EventHandlers/EnviromentEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/EnviromentEventHandlers.cs
@@ -47,4 +47,12 @@ namespace Smod2.EventHandlers
 		/// </summary>  
 		void OnSummonVehicle(SummonVehicleEvent ev);
 	}
+
+    public interface IEventHandlerGeneratorFinish : IEventHandler
+    {
+        /// <summary>
+        /// Called when a generator becomes engaged.
+        /// </summary>
+        void OnGeneratorFinish(PlayerGeneratorFinishEvent ev);
+    }
 }

--- a/Smod2/Smod2/EventSystem/EventHandlers/EnviromentEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/EnviromentEventHandlers.cs
@@ -48,11 +48,11 @@ namespace Smod2.EventHandlers
 		void OnSummonVehicle(SummonVehicleEvent ev);
 	}
 
-    public interface IEventHandlerGeneratorFinish : IEventHandler
-    {
-        /// <summary>
-        /// Called when a generator becomes engaged.
-        /// </summary>
-        void OnGeneratorFinish(GeneratorFinishEvent ev);
-    }
+	public interface IEventHandlerGeneratorFinish : IEventHandler
+	{
+		/// <summary>
+		/// Called when a generator becomes engaged.
+		/// </summary>
+		void OnGeneratorFinish(GeneratorFinishEvent ev);
+	}
 }

--- a/Smod2/Smod2/EventSystem/EventHandlers/EnviromentEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/EnviromentEventHandlers.cs
@@ -53,6 +53,6 @@ namespace Smod2.EventHandlers
         /// <summary>
         /// Called when a generator becomes engaged.
         /// </summary>
-        void OnGeneratorFinish(PlayerGeneratorFinishEvent ev);
+        void OnGeneratorFinish(GeneratorFinishEvent ev);
     }
 }

--- a/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
@@ -313,7 +313,7 @@ namespace Smod2.EventHandlers
 	public interface IEventHandlerGeneratorAccess : IEventHandler
 	{
 		/// <summary>
-		/// Called when a player attempts to open/close a generator
+		/// Called when a player attempts to open/close a generator.
 		/// </summary>
 		void OnGeneratorAccess(PlayerGeneratorAccessEvent ev);
 	}
@@ -321,7 +321,7 @@ namespace Smod2.EventHandlers
 	public interface IEventHandlerGeneratorInsertTablet : IEventHandler
 	{
 		/// <summary>
-		/// Called when a player puts a tablet in or ejects the tablet
+		/// Called when a player puts a tablet in or ejects the tablet.
 		/// </summary>
 		void OnGeneratorInsertTablet(PlayerGeneratorInsertTabletEvent ev);
 	}
@@ -329,7 +329,7 @@ namespace Smod2.EventHandlers
 	public interface IEventHandlerGeneratorEjectTablet : IEventHandler
 	{
 		/// <summary>
-		/// Called when a player puts a tablet in or ejects the tablet
+		/// Called when a player puts a tablet in or ejects the tablet.
 		/// </summary>
 		void OnGeneratorEjectTablet(PlayerGeneratorEjectTabletEvent ev);
 	}

--- a/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
@@ -334,14 +334,6 @@ namespace Smod2.EventHandlers
         void OnGeneratorEjectTablet(PlayerGeneratorEjectTabletEvent ev);
     }
 
-    public interface IEventHandlerGeneratorFinish : IEventHandler
-    {
-        /// <summary>
-        /// Called when a player puts a tablet in or ejects the tablet
-        /// </summary>
-        void OnGeneratorFinish(PlayerGeneratorFinishEvent ev);
-    }
-
     public interface IEventHandler079Door : IEventHandler
     {
         /// <summary>

--- a/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
@@ -302,67 +302,67 @@ namespace Smod2.EventHandlers
 		void OnGrenadeHitPlayer(PlayerGrenadeHitPlayer ev);
 	}
 
-    public interface IEventHandlerGeneratorUnlock : IEventHandler
-    {
-        /// <summary>
-        /// Called when a player attempts to unlock a generator.
-        /// </summary>
-        void OnGeneratorUnlock(PlayerGeneratorUnlockEvent ev);
-    }
+	public interface IEventHandlerGeneratorUnlock : IEventHandler
+	{
+		/// <summary>
+		/// Called when a player attempts to unlock a generator.
+		/// </summary>
+		void OnGeneratorUnlock(PlayerGeneratorUnlockEvent ev);
+	}
 
-    public interface IEventHandlerGeneratorAccess : IEventHandler
-    {
-        /// <summary>
-        /// Called when a player attempts to open/close a generator
-        /// </summary>
-        void OnGeneratorAccess(PlayerGeneratorAccessEvent ev);
-    }
+	public interface IEventHandlerGeneratorAccess : IEventHandler
+	{
+		/// <summary>
+		/// Called when a player attempts to open/close a generator
+		/// </summary>
+		void OnGeneratorAccess(PlayerGeneratorAccessEvent ev);
+	}
 
-    public interface IEventHandlerGeneratorInsertTablet : IEventHandler
-    {
-        /// <summary>
-        /// Called when a player puts a tablet in or ejects the tablet
-        /// </summary>
-        void OnGeneratorInsertTablet(PlayerGeneratorInsertTabletEvent ev);
-    }
+	public interface IEventHandlerGeneratorInsertTablet : IEventHandler
+	{
+		/// <summary>
+		/// Called when a player puts a tablet in or ejects the tablet
+		/// </summary>
+		void OnGeneratorInsertTablet(PlayerGeneratorInsertTabletEvent ev);
+	}
 
-    public interface IEventHandlerGeneratorEjectTablet : IEventHandler
-    {
-        /// <summary>
-        /// Called when a player puts a tablet in or ejects the tablet
-        /// </summary>
-        void OnGeneratorEjectTablet(PlayerGeneratorEjectTabletEvent ev);
-    }
+	public interface IEventHandlerGeneratorEjectTablet : IEventHandler
+	{
+		/// <summary>
+		/// Called when a player puts a tablet in or ejects the tablet
+		/// </summary>
+		void OnGeneratorEjectTablet(PlayerGeneratorEjectTabletEvent ev);
+	}
 
-    public interface IEventHandler079Door : IEventHandler
-    {
-        /// <summary>
-        /// Called when SCP-079 opens/closes doors.
-        /// </summary>
-        void On079Door(Player079DoorEvent ev);
-    }
+	public interface IEventHandler079Door : IEventHandler
+	{
+		/// <summary>
+		/// Called when SCP-079 opens/closes doors.
+		/// </summary>
+		void On079Door(Player079DoorEvent ev);
+	}
 
-    public interface IEventHandler079Lock : IEventHandler
-    {
-        /// <summary>
-        /// Called when SCP-079 locks/unlocks doors.
-        /// </summary>
-        void On079Lock(Player079LockEvent ev);
-    }
+	public interface IEventHandler079Lock : IEventHandler
+	{
+		/// <summary>
+		/// Called when SCP-079 locks/unlocks doors.
+		/// </summary>
+		void On079Lock(Player079LockEvent ev);
+	}
 
-    public interface IEventHandler079Elevator : IEventHandler
-    {
-        /// <summary>
-        /// Called when SCP-079 sends an elevator up/down.
-        /// </summary>
-        void On079Elevator(Player079ElevatorEvent ev);
-    }
+	public interface IEventHandler079Elevator : IEventHandler
+	{
+		/// <summary>
+		/// Called when SCP-079 sends an elevator up/down.
+		/// </summary>
+		void On079Elevator(Player079ElevatorEvent ev);
+	}
 
-    public interface IEventHandler079TeslaGate : IEventHandler
-    {
-        /// <summary>
-        /// Called when SCP-079 triggers a tesla gate.
-        /// </summary>
-        void On079TeslaGate(Player079TeslaGateEvent ev);
-    }
+	public interface IEventHandler079TeslaGate : IEventHandler
+	{
+		/// <summary>
+		/// Called when SCP-079 triggers a tesla gate.
+		/// </summary>
+		void On079TeslaGate(Player079TeslaGateEvent ev);
+	}
 }

--- a/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
@@ -301,4 +301,76 @@ namespace Smod2.EventHandlers
 		/// <summary>
 		void OnGrenadeHitPlayer(PlayerGrenadeHitPlayer ev);
 	}
+
+    public interface IEventHandlerGeneratorUnlock : IEventHandler
+    {
+        /// <summary>
+        /// Called when a player attempts to unlock a generator.
+        /// </summary>
+        void OnGeneratorUnlock(PlayerGeneratorUnlockEvent ev);
+    }
+
+    public interface IEventHandlerGeneratorAccess : IEventHandler
+    {
+        /// <summary>
+        /// Called when a player attempts to open/close a generator
+        /// </summary>
+        void OnGeneratorAccess(PlayerGeneratorAccessEvent ev);
+    }
+
+    public interface IEventHandlerGeneratorInsertTablet : IEventHandler
+    {
+        /// <summary>
+        /// Called when a player puts a tablet in or ejects the tablet
+        /// </summary>
+        void OnGeneratorInsertTablet(PlayerGeneratorInsertTabletEvent ev);
+    }
+
+    public interface IEventHandlerGeneratorEjectTablet : IEventHandler
+    {
+        /// <summary>
+        /// Called when a player puts a tablet in or ejects the tablet
+        /// </summary>
+        void OnGeneratorEjectTablet(PlayerGeneratorEjectTabletEvent ev);
+    }
+
+    public interface IEventHandlerGeneratorFinish : IEventHandler
+    {
+        /// <summary>
+        /// Called when a player puts a tablet in or ejects the tablet
+        /// </summary>
+        void OnGeneratorFinish(PlayerGeneratorFinishEvent ev);
+    }
+
+    public interface IEventHandler079Door : IEventHandler
+    {
+        /// <summary>
+        /// Called when SCP-079 opens/closes doors.
+        /// </summary>
+        void On079Door(Player079DoorEvent ev);
+    }
+
+    public interface IEventHandler079Lock : IEventHandler
+    {
+        /// <summary>
+        /// Called when SCP-079 locks/unlocks doors.
+        /// </summary>
+        void On079Lock(Player079LockEvent ev);
+    }
+
+    public interface IEventHandler079Elevator : IEventHandler
+    {
+        /// <summary>
+        /// Called when SCP-079 sends an elevator up/down.
+        /// </summary>
+        void On079Elevator(Player079ElevatorEvent ev);
+    }
+
+    public interface IEventHandler079TeslaGate : IEventHandler
+    {
+        /// <summary>
+        /// Called when SCP-079 triggers a tesla gate.
+        /// </summary>
+        void On079TeslaGate(Player079TeslaGateEvent ev);
+    }
 }

--- a/Smod2/Smod2/EventSystem/Events/EnvironmentEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/EnvironmentEvents.cs
@@ -103,18 +103,18 @@ namespace Smod2.Events
 		}
 	}
 
-    public class GeneratorFinishEvent : Event
-    {
-        public Generator Generator { get; }
+	public class GeneratorFinishEvent : Event
+	{
+		public Generator Generator { get; }
 
-        public GeneratorFinishEvent(Generator generator)
-        {
-            Generator = generator;
-        }
+		public GeneratorFinishEvent(Generator generator)
+		{
+			Generator = generator;
+		}
 
-        public override void ExecuteHandler(IEventHandler handler)
-        {
-            ((IEventHandlerGeneratorFinish)handler).OnGeneratorFinish(this);
-        }
-    }
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandlerGeneratorFinish)handler).OnGeneratorFinish(this);
+		}
+	}
 }

--- a/Smod2/Smod2/EventSystem/Events/EnvironmentEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/EnvironmentEvents.cs
@@ -102,4 +102,19 @@ namespace Smod2.Events
 			((IEventHandlerSummonVehicle)handler).OnSummonVehicle(this);
 		}
 	}
+
+    public class GeneratorFinishEvent : Event
+    {
+        public Generator Generator { get; }
+
+        public GeneratorFinishEvent(Generator generator)
+        {
+            Generator = generator;
+        }
+
+        public override void ExecuteHandler(IEventHandler handler)
+        {
+            ((IEventHandlerGeneratorFinish)handler).OnGeneratorFinish(this);
+        }
+    }
 }

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -674,21 +674,6 @@ namespace Smod2.Events
         }
     }
 
-    public class PlayerGeneratorFinishEvent : PlayerEvent
-    {
-        public Generator Generator { get; }
-
-        public PlayerGeneratorFinishEvent(Player player, Generator generator) : base(player)
-        {
-            Generator = generator;
-        }
-
-        public override void ExecuteHandler(IEventHandler handler)
-        {
-            ((IEventHandlerGeneratorFinish)handler).OnGeneratorFinish(this);
-        }
-    }
-
     public class PlayerGeneratorInsertTabletEvent : PlayerEvent
     {
         public Generator Generator { get; }

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -641,4 +641,149 @@ namespace Smod2.Events
 			((IEventHandlerGrenadeHitPlayer)handler).OnGrenadeHitPlayer(this);
 		}
 	}
+
+    public class PlayerGeneratorUnlockEvent : PlayerEvent
+    {
+        public Generator Generator { get; }
+        public bool Allow { get; set; }
+
+        public PlayerGeneratorUnlockEvent(Player player, Generator generator) : base(player)
+        {
+            Generator = generator;
+        }
+
+        public override void ExecuteHandler(IEventHandler handler)
+        {
+            ((IEventHandlerGeneratorUnlock)handler).OnGeneratorUnlock(this);
+        }
+    }
+
+    public class PlayerGeneratorAccessEvent : PlayerEvent
+    {
+        public Generator Generator { get; }
+        public bool Allow { get; set; }
+
+        public PlayerGeneratorAccessEvent(Player player, Generator generator) : base(player)
+        {
+            Generator = generator;
+        }
+
+        public override void ExecuteHandler(IEventHandler handler)
+        {
+            ((IEventHandlerGeneratorAccess)handler).OnGeneratorAccess(this);
+        }
+    }
+
+    public class PlayerGeneratorFinishEvent : PlayerEvent
+    {
+        public Generator Generator { get; }
+
+        public PlayerGeneratorFinishEvent(Player player, Generator generator) : base(player)
+        {
+            Generator = generator;
+        }
+
+        public override void ExecuteHandler(IEventHandler handler)
+        {
+            ((IEventHandlerGeneratorFinish)handler).OnGeneratorFinish(this);
+        }
+    }
+
+    public class PlayerGeneratorInsertTabletEvent : PlayerEvent
+    {
+        public Generator Generator { get; }
+        public bool Allow { get; set; }
+        public bool RemoveTablet { get; set; }
+
+        public PlayerGeneratorInsertTabletEvent(Player player, Generator generator) : base(player)
+        {
+            Generator = generator;
+        }
+
+        public override void ExecuteHandler(IEventHandler handler)
+        {
+            ((IEventHandlerGeneratorInsertTablet)handler).OnGeneratorInsertTablet(this);
+        }
+    }
+
+    public class PlayerGeneratorEjectTabletEvent : PlayerEvent
+    {
+        public Generator Generator { get; }
+        public bool Allow { get; set; }
+        public bool SpawnTablet { get; set; }
+
+        public PlayerGeneratorEjectTabletEvent(Player player, Generator generator) : base(player)
+        {
+            Generator = generator;
+        }
+
+        public override void ExecuteHandler(IEventHandler handler)
+        {
+            ((IEventHandlerGeneratorEjectTablet)handler).OnGeneratorEjectTablet(this);
+        }
+    }
+
+    public class Player079DoorEvent : PlayerEvent
+    {
+        public Door Door { get; }
+        public bool Allow { get; set; }
+
+        public Player079DoorEvent(Player player, Door door) : base(player)
+        {
+            Door = door;
+        }
+
+        public override void ExecuteHandler(IEventHandler handler)
+        {
+            ((IEventHandler079Door)handler).On079Door(this);
+        }
+    }
+
+    public class Player079LockEvent : PlayerEvent
+    {
+        public Door Door { get; }
+        public bool Allow { get; set; }
+
+        public Player079LockEvent(Player player, Door door) : base(player)
+        {
+            Door = door;
+        }
+
+        public override void ExecuteHandler(IEventHandler handler)
+        {
+            ((IEventHandler079Lock)handler).On079Lock(this);
+        }
+    }
+
+    public class Player079ElevatorEvent : PlayerEvent
+    {
+        public Elevator Elevator { get; }
+        public bool Allow { get; set; }
+
+        public Player079ElevatorEvent(Player player, Elevator elevator) : base(player)
+        {
+            Elevator = elevator;
+        }
+
+        public override void ExecuteHandler(IEventHandler handler)
+        {
+            ((IEventHandler079Elevator)handler).On079Elevator(this);
+        }
+    }
+
+    public class Player079TeslaGateEvent : PlayerEvent
+    {
+        public TeslaGate TeslaGate { get; }
+        public bool Allow { get; set; }
+
+        public Player079TeslaGateEvent(Player player, TeslaGate teslaGate) : base(player)
+        {
+            TeslaGate = teslaGate;
+        }
+
+        public override void ExecuteHandler(IEventHandler handler)
+        {
+            ((IEventHandler079TeslaGate)handler).On079TeslaGate(this);
+        }
+    }
 }

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -642,133 +642,133 @@ namespace Smod2.Events
 		}
 	}
 
-    public class PlayerGeneratorUnlockEvent : PlayerEvent
-    {
-        public Generator Generator { get; }
-        public bool Allow { get; set; }
+	public class PlayerGeneratorUnlockEvent : PlayerEvent
+	{
+		public Generator Generator { get; }
+		public bool Allow { get; set; }
 
-        public PlayerGeneratorUnlockEvent(Player player, Generator generator) : base(player)
-        {
-            Generator = generator;
-        }
+		public PlayerGeneratorUnlockEvent(Player player, Generator generator) : base(player)
+		{
+			Generator = generator;
+		}
 
-        public override void ExecuteHandler(IEventHandler handler)
-        {
-            ((IEventHandlerGeneratorUnlock)handler).OnGeneratorUnlock(this);
-        }
-    }
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandlerGeneratorUnlock)handler).OnGeneratorUnlock(this);
+		}
+	}
 
-    public class PlayerGeneratorAccessEvent : PlayerEvent
-    {
-        public Generator Generator { get; }
-        public bool Allow { get; set; }
+	public class PlayerGeneratorAccessEvent : PlayerEvent
+	{
+		public Generator Generator { get; }
+		public bool Allow { get; set; }
 
-        public PlayerGeneratorAccessEvent(Player player, Generator generator) : base(player)
-        {
-            Generator = generator;
-        }
+		public PlayerGeneratorAccessEvent(Player player, Generator generator) : base(player)
+		{
+			Generator = generator;
+		}
 
-        public override void ExecuteHandler(IEventHandler handler)
-        {
-            ((IEventHandlerGeneratorAccess)handler).OnGeneratorAccess(this);
-        }
-    }
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandlerGeneratorAccess)handler).OnGeneratorAccess(this);
+		}
+	}
 
-    public class PlayerGeneratorInsertTabletEvent : PlayerEvent
-    {
-        public Generator Generator { get; }
-        public bool Allow { get; set; }
-        public bool RemoveTablet { get; set; }
+	public class PlayerGeneratorInsertTabletEvent : PlayerEvent
+	{
+		public Generator Generator { get; }
+		public bool Allow { get; set; }
+		public bool RemoveTablet { get; set; }
 
-        public PlayerGeneratorInsertTabletEvent(Player player, Generator generator) : base(player)
-        {
-            Generator = generator;
-        }
+		public PlayerGeneratorInsertTabletEvent(Player player, Generator generator) : base(player)
+		{
+			Generator = generator;
+		}
 
-        public override void ExecuteHandler(IEventHandler handler)
-        {
-            ((IEventHandlerGeneratorInsertTablet)handler).OnGeneratorInsertTablet(this);
-        }
-    }
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandlerGeneratorInsertTablet)handler).OnGeneratorInsertTablet(this);
+		}
+	}
 
-    public class PlayerGeneratorEjectTabletEvent : PlayerEvent
-    {
-        public Generator Generator { get; }
-        public bool Allow { get; set; }
-        public bool SpawnTablet { get; set; }
+	public class PlayerGeneratorEjectTabletEvent : PlayerEvent
+	{
+		public Generator Generator { get; }
+		public bool Allow { get; set; }
+		public bool SpawnTablet { get; set; }
 
-        public PlayerGeneratorEjectTabletEvent(Player player, Generator generator) : base(player)
-        {
-            Generator = generator;
-        }
+		public PlayerGeneratorEjectTabletEvent(Player player, Generator generator) : base(player)
+		{
+			Generator = generator;
+		}
 
-        public override void ExecuteHandler(IEventHandler handler)
-        {
-            ((IEventHandlerGeneratorEjectTablet)handler).OnGeneratorEjectTablet(this);
-        }
-    }
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandlerGeneratorEjectTablet)handler).OnGeneratorEjectTablet(this);
+		}
+	}
 
-    public class Player079DoorEvent : PlayerEvent
-    {
-        public Door Door { get; }
-        public bool Allow { get; set; }
+	public class Player079DoorEvent : PlayerEvent
+	{
+		public Door Door { get; }
+		public bool Allow { get; set; }
 
-        public Player079DoorEvent(Player player, Door door) : base(player)
-        {
-            Door = door;
-        }
+		public Player079DoorEvent(Player player, Door door) : base(player)
+		{
+			Door = door;
+		}
 
-        public override void ExecuteHandler(IEventHandler handler)
-        {
-            ((IEventHandler079Door)handler).On079Door(this);
-        }
-    }
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandler079Door)handler).On079Door(this);
+		}
+	}
 
-    public class Player079LockEvent : PlayerEvent
-    {
-        public Door Door { get; }
-        public bool Allow { get; set; }
+	public class Player079LockEvent : PlayerEvent
+	{
+		public Door Door { get; }
+		public bool Allow { get; set; }
 
-        public Player079LockEvent(Player player, Door door) : base(player)
-        {
-            Door = door;
-        }
+		public Player079LockEvent(Player player, Door door) : base(player)
+		{
+			Door = door;
+		}
 
-        public override void ExecuteHandler(IEventHandler handler)
-        {
-            ((IEventHandler079Lock)handler).On079Lock(this);
-        }
-    }
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandler079Lock)handler).On079Lock(this);
+		}
+	}
 
-    public class Player079ElevatorEvent : PlayerEvent
-    {
-        public Elevator Elevator { get; }
-        public bool Allow { get; set; }
+	public class Player079ElevatorEvent : PlayerEvent
+	{
+		public Elevator Elevator { get; }
+		public bool Allow { get; set; }
 
-        public Player079ElevatorEvent(Player player, Elevator elevator) : base(player)
-        {
-            Elevator = elevator;
-        }
+		public Player079ElevatorEvent(Player player, Elevator elevator) : base(player)
+		{
+			Elevator = elevator;
+		}
 
-        public override void ExecuteHandler(IEventHandler handler)
-        {
-            ((IEventHandler079Elevator)handler).On079Elevator(this);
-        }
-    }
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandler079Elevator)handler).On079Elevator(this);
+		}
+	}
 
-    public class Player079TeslaGateEvent : PlayerEvent
-    {
-        public TeslaGate TeslaGate { get; }
-        public bool Allow { get; set; }
+	public class Player079TeslaGateEvent : PlayerEvent
+	{
+		public TeslaGate TeslaGate { get; }
+		public bool Allow { get; set; }
 
-        public Player079TeslaGateEvent(Player player, TeslaGate teslaGate) : base(player)
-        {
-            TeslaGate = teslaGate;
-        }
+		public Player079TeslaGateEvent(Player player, TeslaGate teslaGate) : base(player)
+		{
+			TeslaGate = teslaGate;
+		}
 
-        public override void ExecuteHandler(IEventHandler handler)
-        {
-            ((IEventHandler079TeslaGate)handler).On079TeslaGate(this);
-        }
-    }
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandler079TeslaGate)handler).On079TeslaGate(this);
+		}
+	}
 }


### PR DESCRIPTION
Adds new `Generator` API object to represent the new 079 generators. Also adds new events using these generators as well as 079 interaction circles, almost all of which have a settable boolean `Allow` to allow/disallow 079 or generators from doing something.