### PR TITLE
More 079 API

### DIFF
--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -108,39 +108,39 @@ namespace Smod2.API
 
 	public enum ZoneType
 	{
-		UNDEFINED = -1,
-		LCZ = 0,
-		HCZ = 1,
-		ENTRANCE = 2
+		UNDEFINED = 0,
+		LCZ = 1,
+		HCZ = 2,
+		ENTRANCE = 3
 	}
 
 	public enum RoomType
 	{
-		UNDEFINED = -1,
-		WC00 = 11,
-		SCP_914 = 17,
-		AIRLOCK_00 = 22,
-		AIRLOCK_01 = 23,
-		CHECKPOINT_A = 20,
-		CHECKPOINT_B = 19,
-		HCZ_ARMORY = 1,
-		SERVER_ROOM = 2,
-		MICROHID = 3,
-		NUKE = 4,
-		SCP_012 = 12,
-		SCP_049 = 5,
-		SCP_079 = 6,
-		SCP_096 = 7,
-		SCP_106 = 8,
-		SCP_372 = 13,
-		SCP_939 = 9,
-		ENTRANCE_CHECKPOINT = 0,
-		PC = 10,
-		GATE_A = 14,
-		GATE_B = 15,
-		CAFE = 16,
-		UPSTAIRS = 21,
-		INTERCOM = 18
+		UNDEFINED = 0,
+		WC00 = 1,
+		SCP_914 = 2,
+		AIRLOCK_00 = 3,
+		AIRLOCK_01 = 4,
+		CHECKPOINT_A = 5,
+		CHECKPOINT_B = 6,
+		HCZ_ARMORY = 7,
+		SERVER_ROOM = 8,
+		MICROHID = 9,
+		NUKE = 10,
+		SCP_012 = 11,
+		SCP_049 = 12,
+		SCP_079 = 13,
+		SCP_096 = 14,
+		SCP_106 = 15,
+		SCP_372 = 16,
+		SCP_939 = 17,
+		ENTRANCE_CHECKPOINT = 18,
+		PC = 19,
+		GATE_A = 20,
+		GATE_B = 21,
+		CAFE = 22,
+		UPSTAIRS = 23,
+		INTERCOM = 24
 	}
 
 	public enum Scp079InteractionType

--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -130,19 +130,11 @@ namespace Smod2.API
 		public abstract float TimeLeft { get; set; }
 		public abstract Vector Position { get; }
 	}
-
-	public enum ZoneType
-	{
-		UNDEFINED = -1,
-		LCZ = 0,
-		HCZ = 1
-	}
-
+	
 	public abstract class Room
 	{
 		public abstract string ZoneName { get; }
-		public abstract ZoneType Zone { get; }
-		public abstract string Name { get; }
+		public abstract string RoomName { get; }
 
 		public abstract void FlickerLights();
 	}

--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -132,24 +132,24 @@ namespace Smod2.API
 		SCP_079 = 13,
 		SCP_096 = 14,
 		SCP_106 = 15,
-		SCP_173 = 30,
-		SCP_372 = 16,
-		SCP_939 = 17,
-		ENTRANCE_CHECKPOINT = 18,
-		TESLA_GATE = 33,
-		PC_SMALL = 19,
-		PC_LARGE = 23,
-		GATE_A = 20,
-		GATE_B = 21,
-		CAFE = 22,
-		INTERCOM = 24,
-		DR_L = 31,
-		STRAIGHT = 25,
-		CURVE = 26,
-		T_INTERSECTION = 27,
-		X_INTERSECTION = 28,
-		LCZ_ARMORY = 29,
-		CLASS_D_CELLS = 32
+		SCP_173 = 16,
+		SCP_372 = 17,
+		SCP_939 = 18,
+		ENTRANCE_CHECKPOINT = 19,
+		TESLA_GATE = 20,
+		PC_SMALL = 21,
+		PC_LARGE = 22,
+		GATE_A = 23,
+		GATE_B = 24,
+		CAFE = 25,
+		INTERCOM = 26,
+		DR_L = 27,
+		STRAIGHT = 28,
+		CURVE = 29,
+		T_INTERSECTION = 30,
+		X_INTERSECTION = 31,
+		LCZ_ARMORY = 32,
+		CLASS_D_CELLS = 33
 	}
 
 	public enum Scp079InteractionType
@@ -164,6 +164,7 @@ namespace Smod2.API
 		public abstract RoomType RoomType { get; }
 		public abstract int GenericID { get; }
 		public abstract Vector Position { get; }
+		public abstract Vector SpeakerPosition { get; }
 
 		public abstract void FlickerLights();
 		public abstract string[] GetObjectName();

--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -45,6 +45,7 @@ namespace Smod2.API
 		public abstract Vector Position { get; }
 		public abstract string Name { get; }
 		public abstract string Permission { get; }
+		public abstract object GetComponent();
 	}
 
 	public abstract class TeslaGate

--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -132,27 +132,38 @@ namespace Smod2.API
 		SCP_079 = 13,
 		SCP_096 = 14,
 		SCP_106 = 15,
+		SCP_173 = 30,
 		SCP_372 = 16,
 		SCP_939 = 17,
 		ENTRANCE_CHECKPOINT = 18,
-		PC = 19,
+		TESLA_GATE = 33,
+		PC_SMALL = 19,
+		PC_LARGE = 23,
 		GATE_A = 20,
 		GATE_B = 21,
 		CAFE = 22,
-		UPSTAIRS = 23,
-		INTERCOM = 24
+		INTERCOM = 24,
+		DR_L = 31,
+		STRAIGHT = 25,
+		CURVE = 26,
+		T_INTERSECTION = 27,
+		X_INTERSECTION = 28,
+		LCZ_ARMORY = 29,
+		CLASS_D_CELLS = 32
 	}
 
 	public enum Scp079InteractionType
 	{
-		SPEAKER = 4,
-		ELEVATOR = 7
+		CAMERA = 0,
+		SPEAKER = 4
 	}
 
 	public abstract class Room
 	{
 		public abstract ZoneType ZoneType { get; }
 		public abstract RoomType RoomType { get; }
+		public abstract int GenericID { get; }
+		public abstract Vector Position { get; }
 
 		public abstract void FlickerLights();
 		public abstract string[] GetGameName();

--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -166,7 +166,7 @@ namespace Smod2.API
 		public abstract Vector Position { get; }
 
 		public abstract void FlickerLights();
-		public abstract string[] GetGameName();
+		public abstract string[] GetObjectName();
 	}
 
 	public abstract class Generator

--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -12,6 +12,7 @@ namespace Smod2.API
 		public abstract List<PocketDimensionExit> GetPocketDimensionExits();
 		public abstract Dictionary<Vector, Vector> GetElevatorTeleportPoints();
 		public abstract Generator[] GetGenerators();
+		public abstract List<Room> Get079InteractionRooms(Scp079InteractionType type);
 		public abstract void Shake();
 		public abstract bool WarheadDetonated { get; }
 		public abstract bool LCZDecontaminated { get; }
@@ -105,19 +106,56 @@ namespace Smod2.API
 		public abstract Vector Position { get; }
 	}
 
-	public enum GeneratorType
+	public enum ZoneType
 	{
 		UNDEFINED = -1,
-		ENTRANCE_CHECKPOINT = 0,
+		LCZ = 0,
+		HCZ = 1,
+		ENTRANCE = 2
+	}
+
+	public enum RoomType
+	{
+		UNDEFINED = -1,
+		WC00 = 11,
+		SCP_914 = 17,
+		AIRLOCK_00 = 22,
+		AIRLOCK_01 = 23,
+		CHECKPOINT_A = 20,
+		CHECKPOINT_B = 19,
 		HCZ_ARMORY = 1,
 		SERVER_ROOM = 2,
 		MICROHID = 3,
 		NUKE = 4,
+		SCP_012 = 12,
 		SCP_049 = 5,
 		SCP_079 = 6,
 		SCP_096 = 7,
 		SCP_106 = 8,
-		SCP_939 = 9
+		SCP_372 = 13,
+		SCP_939 = 9,
+		ENTRANCE_CHECKPOINT = 0,
+		PC = 10,
+		GATE_A = 14,
+		GATE_B = 15,
+		CAFE = 16,
+		UPSTAIRS = 21,
+		INTERCOM = 18
+	}
+
+	public enum Scp079InteractionType
+	{
+		SPEAKER = 4,
+		ELEVATOR = 7
+	}
+
+	public abstract class Room
+	{
+		public abstract ZoneType ZoneType { get; }
+		public abstract RoomType RoomType { get; }
+
+		public abstract void FlickerLights();
+		public abstract string[] GetGameName();
 	}
 
 	public abstract class Generator
@@ -126,16 +164,8 @@ namespace Smod2.API
 		public abstract bool Locked { get; set; }
 		public abstract bool HasTablet { get; set; }
 		public abstract bool Engaged { get; set; }
-		public abstract GeneratorType Type { get; }
 		public abstract float TimeLeft { get; set; }
 		public abstract Vector Position { get; }
-	}
-	
-	public abstract class Room
-	{
-		public abstract string ZoneName { get; }
-		public abstract string RoomName { get; }
-
-		public abstract void FlickerLights();
+		public abstract Room Room { get; }
 	}
 }

--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Smod2.API;
 
 namespace Smod2.API
 {
@@ -50,9 +49,10 @@ namespace Smod2.API
 
 	public abstract class TeslaGate
 	{
-		public abstract void Activate();
+		public abstract void Activate(bool instant = false);
 		public abstract float TriggerDistance { get; set; }
 		public abstract Vector Position { get; }
+		public abstract object GetComponent();
 	}
 
 	public enum ElevatorType
@@ -107,6 +107,7 @@ namespace Smod2.API
 
 	public enum GeneratorType
 	{
+		UNDEFINED = -1,
 		ENTRANCE_CHECKPOINT = 0,
 		HCZ_ARMORY = 1,
 		SERVER_ROOM = 2,
@@ -128,5 +129,21 @@ namespace Smod2.API
 		public abstract GeneratorType Type { get; }
 		public abstract float TimeLeft { get; set; }
 		public abstract Vector Position { get; }
+	}
+
+	public enum ZoneType
+	{
+		UNDEFINED = -1,
+		LCZ = 0,
+		HCZ = 1
+	}
+
+	public abstract class Room
+	{
+		public abstract string ZoneName { get; }
+		public abstract ZoneType Zone { get; }
+		public abstract string Name { get; }
+
+		public abstract void FlickerLights();
 	}
 }

--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -57,6 +57,21 @@ namespace Smod2.API
 		ULTRA_RANGE = 4
 	}
 
+	public enum ExperienceType
+	{
+		KILL_ASSIST_CLASSD = 0,
+		KILL_ASSIST_CHAOS_INSURGENCY = 1,
+		KILL_ASSIST_NINETAILFOX = 2,
+		KILL_ASSIST_SCIENTIST = 3,
+		KILL_ASSIST_SCP = 4,
+		KILL_ASSIST_OTHER = 5,
+		USE_DOOR = 6,
+		USE_LOCKDOWN = 7,
+		USE_TESLAGATE = 8,
+		USE_ELEVATOR = 9,
+		CHEAT = 10
+	}
+
 	public abstract class Player : ICommandSender
 	{
 		internal bool CallSetRoleEvent { get; set; }
@@ -70,6 +85,7 @@ namespace Smod2.API
 		public abstract RadioStatus RadioStatus { get; set; }
 		public abstract bool OverwatchMode { get; set; }
 		public abstract bool DoNotTrack { get; }
+		public abstract Scp079Data Scp079Data { get; }
 
 		public abstract void Kill(DamageType type = DamageType.NUKE);
 		public abstract int GetHealth();
@@ -119,5 +135,25 @@ namespace Smod2.API
 		public abstract void RemoveHandcuffs();
 		public abstract bool GetGhostMode();
 		public abstract void SetGhostMode(bool ghostMode, bool visibleToSpec = true, bool visibleWhenTalking = true);
+	}
+
+	public abstract class Scp079Data
+	{
+		public abstract float Exp { get; set; }
+		public abstract int ExpToLevelUp { get; set; }
+		public abstract int Level { get; set; }
+
+		public abstract float AP { get; set; }
+		public abstract float APPerSecond { get; set; }
+		public abstract float MaxAP { get; set; }
+
+		public abstract float CameraYaw { get; }
+		public abstract float CameraPitch { get; }
+
+		public abstract Door[] GetLockedDoors();
+		public abstract bool Unlock(Door door);
+		public abstract void SetCameraRotation(float yaw, float pitch);
+		public abstract void ShowNotEnoughMana(float current, float needed);
+		public abstract void ShowGainExp(ExperienceType expType);
 	}
 }

--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -145,9 +145,10 @@ namespace Smod2.API
 		public abstract float AP { get; set; }
 		public abstract float APPerSecond { get; set; }
 		public abstract float MaxAP { get; set; }
+		public abstract float SpeakerAPPerSecond { get; set; }
+		public abstract float LockedDoorAPPerSecond { get; set; }
 		public abstract float Yaw { get; }
 		public abstract float Pitch { get; }
-		public abstract Vector Position { get; }
 		public abstract Room Speaker { get; set; }
 		public abstract Vector Camera { get; } //todo: implement api object
 

--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -149,7 +149,7 @@ namespace Smod2.API
 		public abstract float Pitch { get; }
 		public abstract Vector Position { get; }
 		public abstract Room Speaker { get; set; }
-		public abstract Vector Camera { get; set; }
+		public abstract Vector Camera { get; } //todo: implement api object
 
 		public abstract Door[] GetLockedDoors();
 		public abstract void Lock(Door door);

--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -151,9 +151,9 @@ namespace Smod2.API
 		public abstract float CameraPitch { get; }
 
 		public abstract Door[] GetLockedDoors();
+		public abstract void Lock(Door door);
 		public abstract bool Unlock(Door door);
-		public abstract void SetCameraRotation(float yaw, float pitch);
-		public abstract void ShowNotEnoughMana(float current, float needed);
 		public abstract void ShowGainExp(ExperienceType expType);
+		public abstract void ShowLevelUp(int level);
 	}
 }

--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -149,6 +149,7 @@ namespace Smod2.API
 		public abstract float Pitch { get; }
 		public abstract Vector Position { get; }
 		public abstract Room Speaker { get; set; }
+		public abstract Vector Camera { get; set; }
 
 		public abstract Door[] GetLockedDoors();
 		public abstract void Lock(Door door);

--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -142,17 +142,20 @@ namespace Smod2.API
 		public abstract float Exp { get; set; }
 		public abstract int ExpToLevelUp { get; set; }
 		public abstract int Level { get; set; }
-
 		public abstract float AP { get; set; }
 		public abstract float APPerSecond { get; set; }
 		public abstract float MaxAP { get; set; }
-
-		public abstract float CameraYaw { get; }
-		public abstract float CameraPitch { get; }
+		public abstract float Yaw { get; }
+		public abstract float Pitch { get; }
+		public abstract Vector Position { get; }
+		public abstract Room Speaker { get; set; }
 
 		public abstract Door[] GetLockedDoors();
 		public abstract void Lock(Door door);
 		public abstract bool Unlock(Door door);
+		public abstract void TriggerTesla(TeslaGate tesla);
+		public abstract void Lockdown(Room room);
+		public abstract void SetCamera(Vector position, bool lookAt = false);
 		public abstract void ShowGainExp(ExperienceType expType);
 		public abstract void ShowLevelUp(int level);
 	}

--- a/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
@@ -365,4 +365,28 @@ namespace Smod2.EventHandlers
 		/// </summary>
 		void On079TeslaGate(Player079TeslaGateEvent ev);
 	}
+
+	public interface IEventHandler079AddExp : IEventHandler
+	{
+		/// <summary>
+		/// Called when a player's SCP-079 experience is added to.
+		/// </summary>
+		void On079AddExperience(Player079AddExpEvent ev);
+	}
+
+	public interface IEventHandler079LevelUp : IEventHandler
+	{
+		/// <summary>
+		/// Called when a player's SCP-079 level is incremented.
+		/// </summary>
+		void On079LevelUp(Player079LevelUpEvent ev);
+	}
+
+	public interface IEventHandler079UnlockDoors : IEventHandler
+	{
+		/// <summary>
+		/// Called when SCP-079 unlocks all doors.
+		/// </summary>
+		void On079UnlockDoors(Player079UnlockDoorsEvent ev);
+	}
 }

--- a/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
@@ -371,7 +371,7 @@ namespace Smod2.EventHandlers
 		/// <summary>
 		/// Called when a player's SCP-079 experience is added to.
 		/// </summary>
-		void On079AddExperience(Player079AddExpEvent ev);
+		void On079AddExp(Player079AddExpEvent ev);
 	}
 
 	public interface IEventHandler079LevelUp : IEventHandler

--- a/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
@@ -390,11 +390,43 @@ namespace Smod2.EventHandlers
 		void On079UnlockDoors(Player079UnlockDoorsEvent ev);
 	}
 
-	public interface IEventHandler079SwitchCamera : IEventHandler
+	public interface IEventHandler079CameraTeleport : IEventHandler
 	{
 		/// <summary>
 		/// Called when SCP-079 teleports to a new camera.
 		/// </summary>
-		void On079SwitchCamera(Player079SwitchCameraEvent ev);
+		void On079CameraTeleport(Player079CameraTeleportEvent ev);
+	}
+
+	public interface IEventHandler079StartSpeaker : IEventHandler
+	{
+		/// <summary>
+		/// Called when SCP-079 starts using a speaker.
+		/// </summary>
+		void On079StartSpeaker(Player079StartSpeakerEvent ev);
+	}
+
+	public interface IEventHandler079StopSpeaker : IEventHandler
+	{
+		/// <summary>
+		/// Called when SCP-079 stops using a speaker.
+		/// </summary>
+		void On079StopSpeaker(Player079StopSpeakerEvent ev);
+	}
+
+	public interface IEventHandler079Lockdown : IEventHandler
+	{
+		/// <summary>
+		/// Called when SCP-079 uses the lockdown (warning sign) ability.
+		/// </summary>
+		void On079Lockdown(Player079LockdownEvent ev);
+	}
+
+	public interface IEventHandler079ElevatorTeleport : IEventHandler
+	{
+		/// <summary>
+		/// Called when SCP-079 uses an elevator to teleport to a new floor.
+		/// </summary>
+		void On079ElevatorTeleport(Player079ElevatorTeleportEvent ev);
 	}
 }

--- a/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
@@ -389,4 +389,12 @@ namespace Smod2.EventHandlers
 		/// </summary>
 		void On079UnlockDoors(Player079UnlockDoorsEvent ev);
 	}
+
+	public interface IEventHandler079SwitchCamera : IEventHandler
+	{
+		/// <summary>
+		/// Called when SCP-079 teleports to a new camera.
+		/// </summary>
+		void On079SwitchCamera(Player079SwitchCameraEvent ev);
+	}
 }

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -813,4 +813,23 @@ namespace Smod2.Events
 			((IEventHandler079UnlockDoors)handler).On079UnlockDoors(this);
 		}
 	}
+
+	public class Player079SwitchCameraEvent : PlayerEvent
+	{
+		public Vector Camera { get; set; }
+		public bool Allow { get; set; }
+		public float ExpDrain { get; set; }
+
+		public Player079SwitchCameraEvent(Player player, Vector camera, bool allow, float expDrain) : base(player)
+		{
+			Camera = camera;
+			Allow = allow;
+			ExpDrain = expDrain;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandler079SwitchCamera)handler).On079SwitchCamera(this);
+		}
+	}
 }

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -712,10 +712,13 @@ namespace Smod2.Events
 	{
 		public Door Door { get; }
 		public bool Allow { get; set; }
+		public float ExpDrain { get; set; }
 
-		public Player079DoorEvent(Player player, Door door) : base(player)
+		public Player079DoorEvent(Player player, Door door, bool allow, float expDrain) : base(player)
 		{
 			Door = door;
+			Allow = allow;
+			ExpDrain = expDrain;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -728,10 +731,13 @@ namespace Smod2.Events
 	{
 		public Door Door { get; }
 		public bool Allow { get; set; }
+		public float ExpDrain { get; set; }
 
-		public Player079LockEvent(Player player, Door door) : base(player)
+		public Player079LockEvent(Player player, Door door, bool allow, float expDrain) : base(player)
 		{
 			Door = door;
+			Allow = allow;
+			ExpDrain = expDrain;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -744,10 +750,13 @@ namespace Smod2.Events
 	{
 		public Elevator Elevator { get; }
 		public bool Allow { get; set; }
+		public float ExpDrain { get; set; }
 
-		public Player079ElevatorEvent(Player player, Elevator elevator) : base(player)
+		public Player079ElevatorEvent(Player player, Elevator elevator, bool allow, float expDrain) : base(player)
 		{
 			Elevator = elevator;
+			Allow = allow;
+			ExpDrain = expDrain;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -760,10 +769,13 @@ namespace Smod2.Events
 	{
 		public TeslaGate TeslaGate { get; }
 		public bool Allow { get; set; }
+		public float ExpDrain { get; set; }
 
-		public Player079TeslaGateEvent(Player player, TeslaGate teslaGate) : base(player)
+		public Player079TeslaGateEvent(Player player, TeslaGate teslaGate, bool allow, float expDrain) : base(player)
 		{
 			TeslaGate = teslaGate;
+			Allow = allow;
+			ExpDrain = expDrain;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -814,13 +826,13 @@ namespace Smod2.Events
 		}
 	}
 
-	public class Player079SwitchCameraEvent : PlayerEvent
+	public class Player079CameraTeleportEvent : PlayerEvent
 	{
 		public Vector Camera { get; set; }
 		public bool Allow { get; set; }
 		public float ExpDrain { get; set; }
 
-		public Player079SwitchCameraEvent(Player player, Vector camera, bool allow, float expDrain) : base(player)
+		public Player079CameraTeleportEvent(Player player, Vector camera, bool allow, float expDrain) : base(player)
 		{
 			Camera = camera;
 			Allow = allow;
@@ -829,7 +841,81 @@ namespace Smod2.Events
 
 		public override void ExecuteHandler(IEventHandler handler)
 		{
-			((IEventHandler079SwitchCamera)handler).On079SwitchCamera(this);
+			((IEventHandler079CameraTeleport)handler).On079CameraTeleport(this);
+		}
+	}
+
+	public class Player079StartSpeakerEvent : PlayerEvent
+	{
+		public Room Room { get; }
+		public bool Allow { get; set; }
+		public float ExpDrain { get; set; }
+
+		public Player079StartSpeakerEvent(Player player, Room room, bool allow, float expDrain) : base(player)
+		{
+			Room = room;
+			Allow = allow;
+			ExpDrain = expDrain;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandler079StartSpeaker)handler).On079StartSpeaker(this);
+		}
+	}
+
+	public class Player079StopSpeakerEvent : PlayerEvent
+	{
+		public Room Room { get; }
+		public bool Allow { get; set; }
+
+		public Player079StopSpeakerEvent(Player player, Room room, bool allow) : base(player)
+		{
+			Room = room;
+			Allow = allow;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandler079StopSpeaker)handler).On079StopSpeaker(this);
+		}
+	}
+
+	public class Player079LockdownEvent : PlayerEvent
+	{
+		public Room Room { get; }
+		public bool Allow { get; set; }
+		public float ExpDrain { get; set; }
+
+		public Player079LockdownEvent(Player player, Room room, bool allow, float expDrain) : base(player)
+		{
+			Room = room;
+			Allow = allow;
+			ExpDrain = expDrain;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandler079Lockdown)handler).On079Lockdown(this);
+		}
+	}
+
+	public class Player079ElevatorTeleportEvent : PlayerEvent
+	{
+		public Vector Camera { get; }
+		public bool Allow { get; set; }
+		public float ExpDrain { get; set; }
+
+		public Player079ElevatorTeleportEvent(Player player, Vector camera, bool allow, float expDrain) : base(player)
+		{
+			Camera = camera;
+			Allow = allow;
+			ExpDrain = expDrain;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandler079ElevatorTeleport)handler).On079ElevatorTeleport(this);
 		}
 	}
 }

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -718,13 +718,13 @@ namespace Smod2.Events
 	{
 		public Door Door { get; }
 		public bool Allow { get; set; }
-		public float ExpDrain { get; set; }
+		public float APDrain { get; set; }
 
-		public Player079DoorEvent(Player player, Door door, bool allow, float expDrain) : base(player)
+		public Player079DoorEvent(Player player, Door door, bool allow, float apDrain) : base(player)
 		{
 			Door = door;
 			Allow = allow;
-			ExpDrain = expDrain;
+			APDrain = apDrain;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -737,13 +737,13 @@ namespace Smod2.Events
 	{
 		public Door Door { get; }
 		public bool Allow { get; set; }
-		public float ExpDrain { get; set; }
+		public float APDrain { get; set; }
 
-		public Player079LockEvent(Player player, Door door, bool allow, float expDrain) : base(player)
+		public Player079LockEvent(Player player, Door door, bool allow, float apDrain) : base(player)
 		{
 			Door = door;
 			Allow = allow;
-			ExpDrain = expDrain;
+			APDrain = apDrain;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -756,13 +756,13 @@ namespace Smod2.Events
 	{
 		public Elevator Elevator { get; }
 		public bool Allow { get; set; }
-		public float ExpDrain { get; set; }
+		public float APDrain { get; set; }
 
-		public Player079ElevatorEvent(Player player, Elevator elevator, bool allow, float expDrain) : base(player)
+		public Player079ElevatorEvent(Player player, Elevator elevator, bool allow, float apDrain) : base(player)
 		{
 			Elevator = elevator;
 			Allow = allow;
-			ExpDrain = expDrain;
+			APDrain = apDrain;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -775,13 +775,13 @@ namespace Smod2.Events
 	{
 		public TeslaGate TeslaGate { get; }
 		public bool Allow { get; set; }
-		public float ExpDrain { get; set; }
+		public float APDrain { get; set; }
 
-		public Player079TeslaGateEvent(Player player, TeslaGate teslaGate, bool allow, float expDrain) : base(player)
+		public Player079TeslaGateEvent(Player player, TeslaGate teslaGate, bool allow, float apDrain) : base(player)
 		{
 			TeslaGate = teslaGate;
 			Allow = allow;
-			ExpDrain = expDrain;
+			APDrain = apDrain;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -836,13 +836,13 @@ namespace Smod2.Events
 	{
 		public Vector Camera { get; set; }
 		public bool Allow { get; set; }
-		public float ExpDrain { get; set; }
+		public float APDrain { get; set; }
 
-		public Player079CameraTeleportEvent(Player player, Vector camera, bool allow, float expDrain) : base(player)
+		public Player079CameraTeleportEvent(Player player, Vector camera, bool allow, float apDrain) : base(player)
 		{
 			Camera = camera;
 			Allow = allow;
-			ExpDrain = expDrain;
+			APDrain = apDrain;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -855,13 +855,13 @@ namespace Smod2.Events
 	{
 		public Room Room { get; }
 		public bool Allow { get; set; }
-		public float ExpDrain { get; set; }
+		public float APDrain { get; set; }
 
-		public Player079StartSpeakerEvent(Player player, Room room, bool allow, float expDrain) : base(player)
+		public Player079StartSpeakerEvent(Player player, Room room, bool allow, float apDrain) : base(player)
 		{
 			Room = room;
 			Allow = allow;
-			ExpDrain = expDrain;
+			APDrain = apDrain;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -891,13 +891,13 @@ namespace Smod2.Events
 	{
 		public Room Room { get; }
 		public bool Allow { get; set; }
-		public float ExpDrain { get; set; }
+		public float APDrain { get; set; }
 
-		public Player079LockdownEvent(Player player, Room room, bool allow, float expDrain) : base(player)
+		public Player079LockdownEvent(Player player, Room room, bool allow, float apDrain) : base(player)
 		{
 			Room = room;
 			Allow = allow;
-			ExpDrain = expDrain;
+			APDrain = apDrain;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -909,14 +909,16 @@ namespace Smod2.Events
 	public class Player079ElevatorTeleportEvent : PlayerEvent
 	{
 		public Vector Camera { get; }
+		public Elevator Elevator { get; }
 		public bool Allow { get; set; }
-		public float ExpDrain { get; set; }
+		public float APDrain { get; set; }
 
-		public Player079ElevatorTeleportEvent(Player player, Vector camera, bool allow, float expDrain) : base(player)
+		public Player079ElevatorTeleportEvent(Player player, Vector camera, Elevator elevator, bool allow, float apDrain) : base(player)
 		{
 			Camera = camera;
+			Elevator = elevator;
 			Allow = allow;
-			ExpDrain = expDrain;
+			APDrain = apDrain;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -771,4 +771,46 @@ namespace Smod2.Events
 			((IEventHandler079TeslaGate)handler).On079TeslaGate(this);
 		}
 	}
+
+	public class Player079AddExpEvent : PlayerEvent
+	{
+		public ExperienceType ExperienceType { get; }
+		public float ExpToAdd { get; set; }
+
+		public Player079AddExpEvent(Player player, ExperienceType experienceType, float expToAdd) : base(player)
+		{
+			ExperienceType = experienceType;
+			ExpToAdd = expToAdd;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandler079AddExp)handler).On079AddExperience(this);
+		}
+	}
+
+	public class Player079LevelUpEvent : PlayerEvent
+	{
+		public Player079LevelUpEvent(Player player) : base(player) { }
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandler079LevelUp)handler).On079LevelUp(this);
+		}
+	}
+
+	public class Player079UnlockDoorsEvent : PlayerEvent
+	{
+		public bool Allow { get; set; }
+
+		public Player079UnlockDoorsEvent(Player player, bool allow) : base(player)
+		{
+			Allow = allow;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandler079UnlockDoors)handler).On079UnlockDoors(this);
+		}
+	}
 }

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -785,7 +785,7 @@ namespace Smod2.Events
 
 		public override void ExecuteHandler(IEventHandler handler)
 		{
-			((IEventHandler079AddExp)handler).On079AddExperience(this);
+			((IEventHandler079AddExp)handler).On079AddExp(this);
 		}
 	}
 

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -647,9 +647,10 @@ namespace Smod2.Events
 		public Generator Generator { get; }
 		public bool Allow { get; set; }
 
-		public PlayerGeneratorUnlockEvent(Player player, Generator generator) : base(player)
+		public PlayerGeneratorUnlockEvent(Player player, Generator generator, bool allow) : base(player)
 		{
 			Generator = generator;
+			Allow = allow;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -663,9 +664,10 @@ namespace Smod2.Events
 		public Generator Generator { get; }
 		public bool Allow { get; set; }
 
-		public PlayerGeneratorAccessEvent(Player player, Generator generator) : base(player)
+		public PlayerGeneratorAccessEvent(Player player, Generator generator, bool allow) : base(player)
 		{
 			Generator = generator;
+			Allow = allow;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -680,9 +682,11 @@ namespace Smod2.Events
 		public bool Allow { get; set; }
 		public bool RemoveTablet { get; set; }
 
-		public PlayerGeneratorInsertTabletEvent(Player player, Generator generator) : base(player)
+		public PlayerGeneratorInsertTabletEvent(Player player, Generator generator, bool allow, bool removeTablet) : base(player)
 		{
 			Generator = generator;
+			Allow = allow;
+			RemoveTablet = removeTablet;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -697,9 +701,11 @@ namespace Smod2.Events
 		public bool Allow { get; set; }
 		public bool SpawnTablet { get; set; }
 
-		public PlayerGeneratorEjectTabletEvent(Player player, Generator generator) : base(player)
+		public PlayerGeneratorEjectTabletEvent(Player player, Generator generator, bool allow, bool spawnTablet) : base(player)
 		{
 			Generator = generator;
+			Allow = allow;
+			SpawnTablet = spawnTablet;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)


### PR DESCRIPTION
Changes:
* Adds `Scp079Data` object which can be accessed from a `Player` object. This allows plugins to perform SCP-079 actions as if the player did them (basically an `Scp079PlayerScript` wrapper). Calling something that can be done via an interaction in game (e.g. locking a door as a player) will not grant or show XP, but the `float Exp` property can be added to and the `void ShowGainExp(ExperienceType expType)` method can be used to simulate a player gaining XP regardless.
* Adds `Room` object which are found in the `Generator` object (replaces `GeneratorType` as well), `List<Room> Map.Get079InteractionRooms(Scp079InteractionType type)` (with supported interactions in the enum), and new speaker and lockdown events.
* Adds `object GetComponent()` to `Door` and `TeslaGate` so `Scp079Data` can get the Unity components of Smod API objects.
* Adds parameter `bool instant` (default false) to `void TeslaGate.Trigger()` to take advantage of the existing SCP-079 instant-tesla code.
* Adds `float APDrain` to existing SCP-079 interaction events. This allows plugins to adjust how much AP an interaction takes. If this is greater than the current AP and `Allow` is set to true, **the interaction will still pass** (and the . Of course, `Allow` is set before the events are run to if the SCP-079 instance has enough AP, so as long as you do not modify the `float APDrain` property you do not need to set the `Allow` property to if the SCP-079 instance has more than that amount of AP.