### PR TITLE
Added a permissions system to support permission plugins

### DIFF
--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -126,6 +126,10 @@ namespace Smod2.API
 		public abstract void HideTag(bool enable);
 		public abstract void PersonalBroadcast(uint duration, string message, bool isMonoSpaced);
 		public abstract void PersonalClearBroadcasts();
+        public bool HasPermission(string permissionName)
+        {
+            return PluginManager.Manager.PermissionsManager.CheckPermission(this, permissionName);
+        }
 		/// <summary>  
 		/// Get SCP-106's portal position. Returns zero if Player is not SCP-106 or SCP-106 hasn't created one.
 		/// </summary> 

--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -126,10 +126,10 @@ namespace Smod2.API
 		public abstract void HideTag(bool enable);
 		public abstract void PersonalBroadcast(uint duration, string message, bool isMonoSpaced);
 		public abstract void PersonalClearBroadcasts();
-        public bool HasPermission(string permissionName)
-        {
-            return PluginManager.Manager.PermissionsManager.CheckPermission(this, permissionName);
-        }
+		public bool HasPermission(string permissionName)
+		{
+			return PluginManager.Manager.PermissionsManager.CheckPermission(this, permissionName);
+		}
 		/// <summary>  
 		/// Get SCP-106's portal position. Returns zero if Player is not SCP-106 or SCP-106 hasn't created one.
 		/// </summary> 

--- a/Smod2/Smod2/Permissions/IPermissionsHandler.cs
+++ b/Smod2/Smod2/Permissions/IPermissionsHandler.cs
@@ -2,18 +2,18 @@ using Smod2.API;
 
 namespace Smod2.Permissions
 {
-    public interface IPermissionsHandler
-    {
-        /// <summary>
-        /// Queries a plugin for player permissions.
-        /// </summary>
-        /// <param name="player">The player to check the permission of.</param>
-        /// <param name="permissionName">The name of the permission to check.</param>
-        /// <returns>
-        /// -1 for negative permission. (Stops other handlers from allowing it)
-        /// 0 for no permission.
-        /// 1 for positive permission.
-        /// </returns>
-        short CheckPermission(Player player, string permissionName);
-    }
+	public interface IPermissionsHandler
+	{
+		/// <summary>
+		/// Queries a plugin for player permissions.
+		/// </summary>
+		/// <param name="player">The player to check the permission of.</param>
+		/// <param name="permissionName">The name of the permission to check.</param>
+		/// <returns>
+		/// -1 for negative permission. (Stops other handlers from allowing it)
+		/// 0 for no permission.
+		/// 1 for positive permission.
+		/// </returns>
+		short CheckPermission(Player player, string permissionName);
+	}
 }

--- a/Smod2/Smod2/Permissions/IPermissionsHandler.cs
+++ b/Smod2/Smod2/Permissions/IPermissionsHandler.cs
@@ -1,0 +1,19 @@
+﻿using Smod2.API;
+
+namespace Smod2.Permissions
+{
+    public interface IPermissionsHandler
+    {
+        /// <summary>
+        /// Queries a plugin for player permissions.
+        /// </summary>
+        /// <param name="player">The player to check the permission of.</param>
+        /// <param name="permissionName">The name of the permission to check.</param>
+        /// <returns>
+        /// -1 for negative permission. (Same as 0 but stops other handlers from allowing it)
+        /// 0 for no permission.
+        /// 1 for positive permission.
+        /// </returns>
+        short CheckPermission(Player player, string permissionName);
+    }
+}

--- a/Smod2/Smod2/Permissions/IPermissionsHandler.cs
+++ b/Smod2/Smod2/Permissions/IPermissionsHandler.cs
@@ -1,4 +1,4 @@
-﻿using Smod2.API;
+using Smod2.API;
 
 namespace Smod2.Permissions
 {
@@ -10,7 +10,7 @@ namespace Smod2.Permissions
         /// <param name="player">The player to check the permission of.</param>
         /// <param name="permissionName">The name of the permission to check.</param>
         /// <returns>
-        /// -1 for negative permission. (Same as 0 but stops other handlers from allowing it)
+        /// -1 for negative permission. (Stops other handlers from allowing it)
         /// 0 for no permission.
         /// 1 for positive permission.
         /// </returns>

--- a/Smod2/Smod2/Permissions/PermissionsManager.cs
+++ b/Smod2/Smod2/Permissions/PermissionsManager.cs
@@ -5,37 +5,39 @@ namespace Smod2.Permissions
 {
     public class PermissionsManager
     {
-        // TODO: Add plugin to remove handlers on plugin disable
-        private List<IPermissionsHandler> permissionHandlers;
+        private List<IPermissionsHandler> permissionHandlers = new List<IPermissionsHandler>();
 
-        bool RegisterHandler(IPermissionsHandler handler)
+        public bool RegisterHandler(IPermissionsHandler handler)
         {
-            if(handler == null)
+            if (handler == null)
             {
-                PluginManager.Manager.Logger.Error("PERMISSIONS_MANAGER","Failed to add Permissions Handler as it was null.");
+                PluginManager.Manager.Logger.Error("PERMISSIONS_MANAGER", "Failed to add Permissions Handler as it was null.");
                 return false;
             }
+
             permissionHandlers.Add(handler);
+
             PluginManager.Manager.Logger.Debug("PERMISSIONS_MANAGER", "Added new permissions handler.");
             return true;
         }
 
-        void UnregisterHandler(IPermissionsHandler handler)
+        public void UnregisterHandler(IPermissionsHandler handler)
         {
             permissionHandlers.Remove(handler);
         }
 
-        bool CheckPermission(Player player, string permissionName)
+        public bool CheckPermission(Player player, string permissionName)
         {
             bool allowed = false;
-            foreach(IPermissionsHandler handler in permissionHandlers)
+            foreach (IPermissionsHandler handler in permissionHandlers)
             {
                 // Checks each permission handler, aborts if this permission node is negative
-                switch(handler.CheckPermission(player, permissionName))
+                switch (handler.CheckPermission(player, permissionName))
                 {
                     case 1:
                         allowed = true;
                         break;
+
                     case -1:
                         return false;
                 }

--- a/Smod2/Smod2/Permissions/PermissionsManager.cs
+++ b/Smod2/Smod2/Permissions/PermissionsManager.cs
@@ -1,4 +1,4 @@
-using Smod2.API;
+﻿using Smod2.API;
 using System.Collections.Generic;
 
 namespace Smod2.Permissions
@@ -36,6 +36,17 @@ namespace Smod2.Permissions
         public void UnregisterHandler(IPermissionsHandler handler)
         {
             permissionHandlers.Remove(handler);
+        }
+
+        // Used by plugins to specicy permissions which should be given to everyone by default
+        public bool RegisterDefaultPermission(string permissionName)
+        {
+            return defaultPermissionsHandler.AddPermission(permissionName);
+        }
+
+        public bool UnregisterDefaultPermission(string permissionName)
+        {
+            return defaultPermissionsHandler.AddPermission(permissionName);
         }
 
         public bool CheckPermission(Player player, string permissionName)

--- a/Smod2/Smod2/Permissions/PermissionsManager.cs
+++ b/Smod2/Smod2/Permissions/PermissionsManager.cs
@@ -1,28 +1,26 @@
-﻿using Smod2.API;
+using Smod2.API;
 using System.Collections.Generic;
 
 namespace Smod2.Permissions
 {
     public class PermissionsManager
     {
-        // TODO: Switch to something with unique members
         private HashSet<IPermissionsHandler> permissionHandlers = new HashSet<IPermissionsHandler>();
 
         public bool RegisterHandler(IPermissionsHandler handler)
         {
             if (handler == null)
             {
-                PluginManager.Manager.Logger.Error("PERMISSIONS_MANAGER", "Failed to add Permissions Handler as it was null.");
+                PluginManager.Manager.Logger.Error("PERMISSIONS_MANAGER", "Failed to add permissions handler as it was null.");
                 return false;
             }
 
             if(permissionHandlers.Add(handler))
             {
-                PluginManager.Manager.Logger.Debug("PERMISSIONS_MANAGER", "Added new permissions handler.");
                 return true;
             }
 
-            PluginManager.Manager.Logger.Warn("PERMISSIONS_MANAGER", "Attempted to add duplicate Permissions Handler.");
+            PluginManager.Manager.Logger.Warn("PERMISSIONS_MANAGER", "Attempted to add duplicate permissions handler.");
             return false;
         }
 
@@ -36,7 +34,7 @@ namespace Smod2.Permissions
             bool allowed = false;
             foreach (IPermissionsHandler handler in permissionHandlers)
             {
-                // Checks each permission handler, aborts if this permission node is negative
+                // Checks each permission handler, aborts if this permission node is negative in any handler
                 switch (handler.CheckPermission(player, permissionName))
                 {
                     case 1:
@@ -47,7 +45,6 @@ namespace Smod2.Permissions
                         return false;
                 }
             }
-
             // True if any permission handler returns positively and none return negatively
             return allowed;
         }

--- a/Smod2/Smod2/Permissions/PermissionsManager.cs
+++ b/Smod2/Smod2/Permissions/PermissionsManager.cs
@@ -7,6 +7,15 @@ namespace Smod2.Permissions
     {
         private HashSet<IPermissionsHandler> permissionHandlers = new HashSet<IPermissionsHandler>();
 
+        private readonly DefaultPermissionsHandler defaultPermissionsHandler = new DefaultPermissionsHandler();
+
+        public PermissionsManager()
+        {
+            // Immediately registers the default permissions handler
+            RegisterHandler(defaultPermissionsHandler);
+        }
+
+        // Used by permission plugins to register themselves as permission handlers
         public bool RegisterHandler(IPermissionsHandler handler)
         {
             if (handler == null)
@@ -47,6 +56,43 @@ namespace Smod2.Permissions
             }
             // True if any permission handler returns positively and none return negatively
             return allowed;
+        }
+    }
+
+    // Plugins can register permissions which are given to everyone by default. Permission plugins can still counter these by returing a negative permission.
+    public class DefaultPermissionsHandler : IPermissionsHandler
+    {
+        private HashSet<string> defaultPerms = new HashSet<string>();
+
+        public short CheckPermission(Player player, string permissionName)
+        {
+            if (defaultPerms.Contains(permissionName))
+            {
+                return 1;
+            }
+            return 0;
+        }
+
+        public bool AddPermission(string permissionName)
+        {
+            if(permissionName == null || permissionName == "")
+            {
+                PluginManager.Manager.Logger.Warn("PERMISSIONS_MANAGER", "Attempted to add default permission but it was empty or null.");
+                return false;
+            }
+            PluginManager.Manager.Logger.Debug("PERMISSIONS_MANAGER", "Added default permission '" + permissionName + "'.");
+            return defaultPerms.Add(permissionName);
+        }
+
+        public bool RemovePermission(string permissionName)
+        {
+            if (permissionName == null || permissionName == "")
+            {
+                PluginManager.Manager.Logger.Warn("PERMISSIONS_MANAGER", "Attempted to remove default permission but string was empty or null.");
+                return false;
+            }
+            PluginManager.Manager.Logger.Debug("PERMISSIONS_MANAGER", "Removed default permission '" + permissionName + "'.");
+            return defaultPerms.Remove(permissionName);
         }
     }
 }

--- a/Smod2/Smod2/Permissions/PermissionsManager.cs
+++ b/Smod2/Smod2/Permissions/PermissionsManager.cs
@@ -1,0 +1,48 @@
+﻿using Smod2.API;
+using System.Collections.Generic;
+
+namespace Smod2.Permissions
+{
+    public class PermissionsManager
+    {
+        // TODO: Add plugin to remove handlers on plugin disable
+        private List<IPermissionsHandler> permissionHandlers;
+
+        bool RegisterHandler(IPermissionsHandler handler)
+        {
+            if(handler == null)
+            {
+                PluginManager.Manager.Logger.Error("PERMISSIONS_MANAGER","Failed to add Permissions Handler as it was null.");
+                return false;
+            }
+            permissionHandlers.Add(handler);
+            PluginManager.Manager.Logger.Debug("PERMISSIONS_MANAGER", "Added new permissions handler.");
+            return true;
+        }
+
+        void UnregisterHandler(IPermissionsHandler handler)
+        {
+            permissionHandlers.Remove(handler);
+        }
+
+        bool CheckPermission(Player player, string permissionName)
+        {
+            bool allowed = false;
+            foreach(IPermissionsHandler handler in permissionHandlers)
+            {
+                // Checks each permission handler, aborts if this permission node is negative
+                switch(handler.CheckPermission(player, permissionName))
+                {
+                    case 1:
+                        allowed = true;
+                        break;
+                    case -1:
+                        return false;
+                }
+            }
+
+            // True if any permission handler returns positively and none return negatively
+            return allowed;
+        }
+    }
+}

--- a/Smod2/Smod2/Permissions/PermissionsManager.cs
+++ b/Smod2/Smod2/Permissions/PermissionsManager.cs
@@ -3,107 +3,107 @@ using System.Collections.Generic;
 
 namespace Smod2.Permissions
 {
-    public class PermissionsManager
-    {
-        private HashSet<IPermissionsHandler> permissionHandlers = new HashSet<IPermissionsHandler>();
+	public class PermissionsManager
+	{
+		private HashSet<IPermissionsHandler> permissionHandlers = new HashSet<IPermissionsHandler>();
 
-        private readonly DefaultPermissionsHandler defaultPermissionsHandler = new DefaultPermissionsHandler();
+		private readonly DefaultPermissionsHandler defaultPermissionsHandler = new DefaultPermissionsHandler();
 
-        public PermissionsManager()
-        {
-            // Immediately registers the default permissions handler
-            RegisterHandler(defaultPermissionsHandler);
-        }
+		public PermissionsManager()
+		{
+			// Immediately registers the default permissions handler
+			RegisterHandler(defaultPermissionsHandler);
+		}
 
-        // Used by permission plugins to register themselves as permission handlers
-        public bool RegisterHandler(IPermissionsHandler handler)
-        {
-            if (handler == null)
-            {
-                PluginManager.Manager.Logger.Error("PERMISSIONS_MANAGER", "Failed to add permissions handler as it was null.");
-                return false;
-            }
+		// Used by permission plugins to register themselves as permission handlers
+		public bool RegisterHandler(IPermissionsHandler handler)
+		{
+			if (handler == null)
+			{
+				PluginManager.Manager.Logger.Error("PERMISSIONS_MANAGER", "Failed to add permissions handler as it was null.");
+				return false;
+			}
 
-            if(permissionHandlers.Add(handler))
-            {
-                return true;
-            }
+			if(permissionHandlers.Add(handler))
+			{
+				return true;
+			}
 
-            PluginManager.Manager.Logger.Warn("PERMISSIONS_MANAGER", "Attempted to add duplicate permissions handler.");
-            return false;
-        }
+			PluginManager.Manager.Logger.Warn("PERMISSIONS_MANAGER", "Attempted to add duplicate permissions handler.");
+			return false;
+		}
 
-        public void UnregisterHandler(IPermissionsHandler handler)
-        {
-            permissionHandlers.Remove(handler);
-        }
+		public void UnregisterHandler(IPermissionsHandler handler)
+		{
+			permissionHandlers.Remove(handler);
+		}
 
-        // Used by plugins to specicy permissions which should be given to everyone by default
-        public bool RegisterDefaultPermission(string permissionName)
-        {
-            return defaultPermissionsHandler.AddPermission(permissionName);
-        }
+		// Used by plugins to specicy permissions which should be given to everyone by default
+		public bool RegisterDefaultPermission(string permissionName)
+		{
+			return defaultPermissionsHandler.AddPermission(permissionName);
+		}
 
-        public bool UnregisterDefaultPermission(string permissionName)
-        {
-            return defaultPermissionsHandler.AddPermission(permissionName);
-        }
+		public bool UnregisterDefaultPermission(string permissionName)
+		{
+			return defaultPermissionsHandler.AddPermission(permissionName);
+		}
 
-        public bool CheckPermission(Player player, string permissionName)
-        {
-            bool allowed = false;
-            foreach (IPermissionsHandler handler in permissionHandlers)
-            {
-                // Checks each permission handler, aborts if this permission node is negative in any handler
-                switch (handler.CheckPermission(player, permissionName))
-                {
-                    case 1:
-                        allowed = true;
-                        break;
+		public bool CheckPermission(Player player, string permissionName)
+		{
+			bool allowed = false;
+			foreach (IPermissionsHandler handler in permissionHandlers)
+			{
+				// Checks each permission handler, aborts if this permission node is negative in any handler
+				switch (handler.CheckPermission(player, permissionName))
+				{
+					case 1:
+						allowed = true;
+						break;
 
-                    case -1:
-                        return false;
-                }
-            }
-            // True if any permission handler returns positively and none return negatively
-            return allowed;
-        }
-    }
+					case -1:
+						return false;
+				}
+			}
+			// True if any permission handler returns positively and none return negatively
+			return allowed;
+		}
+	}
 
-    // Plugins can register permissions which are given to everyone by default. Permission plugins can still counter these by returing a negative permission.
-    public class DefaultPermissionsHandler : IPermissionsHandler
-    {
-        private HashSet<string> defaultPerms = new HashSet<string>();
+	// Plugins can register permissions which are given to everyone by default. Permission plugins can still counter these by returing a negative permission.
+	public class DefaultPermissionsHandler : IPermissionsHandler
+	{
+		private HashSet<string> defaultPerms = new HashSet<string>();
 
-        public short CheckPermission(Player player, string permissionName)
-        {
-            if (defaultPerms.Contains(permissionName))
-            {
-                return 1;
-            }
-            return 0;
-        }
+		public short CheckPermission(Player player, string permissionName)
+		{
+			if (defaultPerms.Contains(permissionName))
+			{
+				return 1;
+			}
+			return 0;
+		}
 
-        public bool AddPermission(string permissionName)
-        {
-            if(permissionName == null || permissionName == "")
-            {
-                PluginManager.Manager.Logger.Warn("PERMISSIONS_MANAGER", "Attempted to add default permission but it was empty or null.");
-                return false;
-            }
-            PluginManager.Manager.Logger.Debug("PERMISSIONS_MANAGER", "Added default permission '" + permissionName + "'.");
-            return defaultPerms.Add(permissionName);
-        }
+		public bool AddPermission(string permissionName)
+		{
+			if(permissionName == null || permissionName == "")
+			{
+				PluginManager.Manager.Logger.Warn("PERMISSIONS_MANAGER", "Attempted to add default permission but it was empty or null.");
+				return false;
+			}
+			PluginManager.Manager.Logger.Debug("PERMISSIONS_MANAGER", "Added default permission '" + permissionName + "'.");
+			return defaultPerms.Add(permissionName);
+		}
 
-        public bool RemovePermission(string permissionName)
-        {
-            if (permissionName == null || permissionName == "")
-            {
-                PluginManager.Manager.Logger.Warn("PERMISSIONS_MANAGER", "Attempted to remove default permission but string was empty or null.");
-                return false;
-            }
-            PluginManager.Manager.Logger.Debug("PERMISSIONS_MANAGER", "Removed default permission '" + permissionName + "'.");
-            return defaultPerms.Remove(permissionName);
-        }
-    }
+		public bool RemovePermission(string permissionName)
+		{
+			if (permissionName == null || permissionName == "")
+			{
+				PluginManager.Manager.Logger.Warn("PERMISSIONS_MANAGER", "Attempted to remove default permission but string was empty or null.");
+				return false;
+			}
+			PluginManager.Manager.Logger.Debug("PERMISSIONS_MANAGER", "Removed default permission '" + permissionName + "'.");
+			return defaultPerms.Remove(permissionName);
+		}
+	}
 }

--- a/Smod2/Smod2/Permissions/PermissionsManager.cs
+++ b/Smod2/Smod2/Permissions/PermissionsManager.cs
@@ -5,7 +5,8 @@ namespace Smod2.Permissions
 {
     public class PermissionsManager
     {
-        private List<IPermissionsHandler> permissionHandlers = new List<IPermissionsHandler>();
+        // TODO: Switch to something with unique members
+        private HashSet<IPermissionsHandler> permissionHandlers = new HashSet<IPermissionsHandler>();
 
         public bool RegisterHandler(IPermissionsHandler handler)
         {
@@ -15,10 +16,14 @@ namespace Smod2.Permissions
                 return false;
             }
 
-            permissionHandlers.Add(handler);
+            if(permissionHandlers.Add(handler))
+            {
+                PluginManager.Manager.Logger.Debug("PERMISSIONS_MANAGER", "Added new permissions handler.");
+                return true;
+            }
 
-            PluginManager.Manager.Logger.Debug("PERMISSIONS_MANAGER", "Added new permissions handler.");
-            return true;
+            PluginManager.Manager.Logger.Warn("PERMISSIONS_MANAGER", "Attempted to add duplicate Permissions Handler.");
+            return false;
         }
 
         public void UnregisterHandler(IPermissionsHandler handler)

--- a/Smod2/Smod2/Plugin.cs
+++ b/Smod2/Smod2/Plugin.cs
@@ -71,7 +71,20 @@ namespace Smod2
             }
         }
 
-		public void AddConfig(ConfigSetting setting)
+        public void RemovePermissionsHandler(IPermissionsHandler handler)
+        {
+            if (PluginManager.Manager.PermissionsManager == null)
+            {
+                this.Error("Failed to remove permissions handler becuase the permissions manager is null");
+            }
+            else
+            {
+                this.Debug(this.Details.name + " unregistered a permission handler.");
+                PluginManager.Manager.PermissionsManager.UnregisterHandler(handler);
+            }
+        }
+
+        public void AddConfig(ConfigSetting setting)
 		{
 			ConfigManager.Manager.RegisterConfig(this, setting);
 		}

--- a/Smod2/Smod2/Plugin.cs
+++ b/Smod2/Smod2/Plugin.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Smod2.EventHandlers;
 using Smod2.Lang;
 using Smod2.API;
+using Smod2.Permissions;
 
 namespace Smod2
 {
@@ -35,6 +36,7 @@ namespace Smod2
 		{
 			eventManager.AddEventHandler(this, eventType, handler, priority);
 		}
+
 		public void AddCommands(string[] commands, ICommandHandler handler)
 		{
 			foreach (string command in commands)
@@ -55,6 +57,19 @@ namespace Smod2
 				PluginManager.Manager.CommandManager.RegisterCommand(this, command, handler);
 			}
 		}
+
+        public void AddPermissionsHandler(IPermissionsHandler handler)
+        {
+            if (PluginManager.Manager.PermissionsManager == null)
+            {
+                this.Error("Failed to register permissions handler becuase the permissions manager is null");
+            }
+            else
+            {
+                this.Debug(this.Details.name + " registered a permission handler.");
+                PluginManager.Manager.PermissionsManager.RegisterHandler(handler);
+            }
+        }
 
 		public void AddConfig(ConfigSetting setting)
 		{

--- a/Smod2/Smod2/Plugin.cs
+++ b/Smod2/Smod2/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Smod2.Attributes;
 using Smod2.Commands;
 using Smod2.Config;
@@ -49,7 +49,7 @@ namespace Smod2
 		{
 			if (PluginManager.Manager.CommandManager == null)
 			{
-				this.Error("Failed to register command handler becuase the command manager is null");
+				this.Error("Failed to register command handler because the command manager is null");
 			}
 			else
 			{
@@ -62,7 +62,7 @@ namespace Smod2
         {
             if (PluginManager.Manager.PermissionsManager == null)
             {
-                this.Error("Failed to register permissions handler becuase the permissions manager is null");
+                this.Error("Failed to register permissions handler because the permissions manager is null");
             }
             else
             {
@@ -75,7 +75,7 @@ namespace Smod2
         {
             if (PluginManager.Manager.PermissionsManager == null)
             {
-                this.Error("Failed to remove permissions handler becuase the permissions manager is null");
+                this.Error("Failed to remove permissions handler because the permissions manager is null");
             }
             else
             {
@@ -98,7 +98,7 @@ namespace Smod2
 		{
 			if (!LangManager.Manager.IsRegistered(this, key))
 			{
-				this.Warn("Trying to access a lang setting [" + key + "] that isnt registered to the plugin, this is bad practice.");
+				this.Warn("Trying to access a lang setting [" + key + "] that isn't registered to the plugin, this is bad practice.");
 			}
 		}
 
@@ -112,7 +112,7 @@ namespace Smod2
 		{
 			if (!ConfigManager.Manager.IsRegistered(this, key))
 			{
-				this.Warn("Trying to access a config setting that isnt registered to the plugin, this is bad practice.");
+				this.Warn("Trying to access a config setting that isn't registered to the plugin, this is bad practice.");
 			}
 		}
 

--- a/Smod2/Smod2/Plugin.cs
+++ b/Smod2/Smod2/Plugin.cs
@@ -58,7 +58,7 @@ namespace Smod2
 			}
 		}
 
-        public void AddPermissionsHandler(IPermissionsHandler handler)
+        public void RegisterPermissionsHandler(IPermissionsHandler handler)
         {
             if (PluginManager.Manager.PermissionsManager == null)
             {
@@ -71,7 +71,7 @@ namespace Smod2
             }
         }
 
-        public void RemovePermissionsHandler(IPermissionsHandler handler)
+        public void UnregisterPermissionsHandler(IPermissionsHandler handler)
         {
             if (PluginManager.Manager.PermissionsManager == null)
             {
@@ -84,7 +84,7 @@ namespace Smod2
             }
         }
 
-        public void RegisterDefaultPermission(string permissionName)
+        public void AddDefaultPermission(string permissionName)
         {
             if (PluginManager.Manager.PermissionsManager == null)
             {
@@ -93,7 +93,7 @@ namespace Smod2
             PluginManager.Manager.PermissionsManager.RegisterDefaultPermission(permissionName);
         }
 
-        public void UnregisterDefaultPermission(string permissionName)
+        public void RemoveDefaultPermission(string permissionName)
         {
             if (PluginManager.Manager.PermissionsManager == null)
             {

--- a/Smod2/Smod2/Plugin.cs
+++ b/Smod2/Smod2/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Smod2.Attributes;
 using Smod2.Commands;
 using Smod2.Config;
@@ -11,8 +11,8 @@ using Smod2.Permissions;
 
 namespace Smod2
 {
-    public abstract class Plugin
-    {
+	public abstract class Plugin
+	{
 		public PluginDetails Details
 		{
 			get;
@@ -58,51 +58,51 @@ namespace Smod2
 			}
 		}
 
-        public void RegisterPermissionsHandler(IPermissionsHandler handler)
-        {
-            if (PluginManager.Manager.PermissionsManager == null)
-            {
-                this.Error("Failed to register permissions handler because the permissions manager is null");
-            }
-            else
-            {
-                this.Debug(this.Details.name + " registered a permission handler.");
-                PluginManager.Manager.PermissionsManager.RegisterHandler(handler);
-            }
-        }
+		public void RegisterPermissionsHandler(IPermissionsHandler handler)
+		{
+			if (PluginManager.Manager.PermissionsManager == null)
+			{
+				this.Error("Failed to register permissions handler because the permissions manager is null");
+			}
+			else
+			{
+				this.Debug(this.Details.name + " registered a permission handler.");
+				PluginManager.Manager.PermissionsManager.RegisterHandler(handler);
+			}
+		}
 
-        public void UnregisterPermissionsHandler(IPermissionsHandler handler)
-        {
-            if (PluginManager.Manager.PermissionsManager == null)
-            {
-                this.Error("Failed to remove permissions handler because the permissions manager is null");
-            }
-            else
-            {
-                this.Debug(this.Details.name + " unregistered a permission handler.");
-                PluginManager.Manager.PermissionsManager.UnregisterHandler(handler);
-            }
-        }
+		public void UnregisterPermissionsHandler(IPermissionsHandler handler)
+		{
+			if (PluginManager.Manager.PermissionsManager == null)
+			{
+				this.Error("Failed to remove permissions handler because the permissions manager is null");
+			}
+			else
+			{
+				this.Debug(this.Details.name + " unregistered a permission handler.");
+				PluginManager.Manager.PermissionsManager.UnregisterHandler(handler);
+			}
+		}
 
-        public void AddDefaultPermission(string permissionName)
-        {
-            if (PluginManager.Manager.PermissionsManager == null)
-            {
-                this.Error("Failed to register default permission because the permissions manager is null");
-            }
-            PluginManager.Manager.PermissionsManager.RegisterDefaultPermission(permissionName);
-        }
+		public void AddDefaultPermission(string permissionName)
+		{
+			if (PluginManager.Manager.PermissionsManager == null)
+			{
+				this.Error("Failed to register default permission because the permissions manager is null");
+			}
+			PluginManager.Manager.PermissionsManager.RegisterDefaultPermission(permissionName);
+		}
 
-        public void RemoveDefaultPermission(string permissionName)
-        {
-            if (PluginManager.Manager.PermissionsManager == null)
-            {
-                this.Error("Failed to unregister default permission because the permissions manager is null");
-            }
-            PluginManager.Manager.PermissionsManager.UnregisterDefaultPermission(permissionName);
-        }
+		public void RemoveDefaultPermission(string permissionName)
+		{
+			if (PluginManager.Manager.PermissionsManager == null)
+			{
+				this.Error("Failed to unregister default permission because the permissions manager is null");
+			}
+			PluginManager.Manager.PermissionsManager.UnregisterDefaultPermission(permissionName);
+		}
 
-        public void AddConfig(ConfigSetting setting)
+		public void AddConfig(ConfigSetting setting)
 		{
 			ConfigManager.Manager.RegisterConfig(this, setting);
 		}

--- a/Smod2/Smod2/Plugin.cs
+++ b/Smod2/Smod2/Plugin.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Smod2.Attributes;
 using Smod2.Commands;
 using Smod2.Config;
@@ -82,6 +82,24 @@ namespace Smod2
                 this.Debug(this.Details.name + " unregistered a permission handler.");
                 PluginManager.Manager.PermissionsManager.UnregisterHandler(handler);
             }
+        }
+
+        public void RegisterDefaultPermission(string permissionName)
+        {
+            if (PluginManager.Manager.PermissionsManager == null)
+            {
+                this.Error("Failed to register default permission because the permissions manager is null");
+            }
+            PluginManager.Manager.PermissionsManager.RegisterDefaultPermission(permissionName);
+        }
+
+        public void UnregisterDefaultPermission(string permissionName)
+        {
+            if (PluginManager.Manager.PermissionsManager == null)
+            {
+                this.Error("Failed to unregister default permission because the permissions manager is null");
+            }
+            PluginManager.Manager.PermissionsManager.UnregisterDefaultPermission(permissionName);
         }
 
         public void AddConfig(ConfigSetting setting)

--- a/Smod2/Smod2/PluginManager.cs
+++ b/Smod2/Smod2/PluginManager.cs
@@ -7,6 +7,7 @@ using Smod2.Commands;
 using Smod2.API;
 using Smod2.Logging;
 using Smod2.Events;
+using Smod2.Permissions;
 
 namespace Smod2
 {
@@ -89,7 +90,20 @@ namespace Smod2
 			}
 		}
 
-		private Server server;
+        private PermissionsManager permissionsManager;
+        public PermissionsManager PermissionsManager
+        {
+            get { return permissionsManager; }
+            set
+            {
+                if (permissionsManager == null)
+                {
+                    permissionsManager = value;
+                }
+            }
+        }
+
+        private Server server;
 		public Server Server
 		{
 			get { return server; }

--- a/Smod2/Smod2/PluginManager.cs
+++ b/Smod2/Smod2/PluginManager.cs
@@ -147,6 +147,7 @@ namespace Smod2
 		{
 			enabledPlugins = new Dictionary<string, Plugin>();
 			disabledPlugins = new Dictionary<string, Plugin>();
+            permissionsManager = new PermissionsManager();
 		}
 
 		public Plugin GetEnabledPlugin(string id)

--- a/Smod2/Smod2/PluginManager.cs
+++ b/Smod2/Smod2/PluginManager.cs
@@ -90,20 +90,20 @@ namespace Smod2
 			}
 		}
 
-        private PermissionsManager permissionsManager;
-        public PermissionsManager PermissionsManager
-        {
-            get { return permissionsManager; }
-            set
-            {
-                if (permissionsManager == null)
-                {
-                    permissionsManager = value;
-                }
-            }
-        }
+		private PermissionsManager permissionsManager;
+		public PermissionsManager PermissionsManager
+		{
+			get { return permissionsManager; }
+			set
+			{
+				if (permissionsManager == null)
+				{
+					permissionsManager = value;
+				}
+			}
+		}
 
-        private Server server;
+		private Server server;
 		public Server Server
 		{
 			get { return server; }
@@ -147,7 +147,7 @@ namespace Smod2
 		{
 			enabledPlugins = new Dictionary<string, Plugin>();
 			disabledPlugins = new Dictionary<string, Plugin>();
-            permissionsManager = new PermissionsManager();
+			permissionsManager = new PermissionsManager();
 		}
 
 		public Plugin GetEnabledPlugin(string id)

--- a/Smod2/Smod2/Smod2.csproj
+++ b/Smod2/Smod2/Smod2.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>E:\SteamLibrary\steamapps\common\SCP Secret Laboratory2\SCPSL_Data\Managed\</OutputPath>
+    <OutputPath>..\..\scpserver\SCPSL_Data\Managed\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -26,7 +26,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>Release\</OutputPath>
+    <OutputPath>..\..\scpserver\SCPSL_Data\Managed\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Smod2/Smod2/Smod2.csproj
+++ b/Smod2/Smod2/Smod2.csproj
@@ -75,6 +75,8 @@
     <Compile Include="LangManager\LangSetting.cs" />
     <Compile Include="LangManager\LangManager.cs" />
     <Compile Include="Logging\Logger.cs" />
+    <Compile Include="Permissions\IPermissionsHandler.cs" />
+    <Compile Include="Permissions\PermissionsManager.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="PluginManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Smod2/Smod2/Smod2.csproj
+++ b/Smod2/Smod2/Smod2.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\scpserver\SCPSL_Data\Managed\</OutputPath>
+    <OutputPath>bin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -26,7 +26,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\scpserver\SCPSL_Data\Managed\</OutputPath>
+    <OutputPath>bin\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
There are no changes to the ServerMod repo accompanying this btw.

- Added `PluginManager.PermissionsManager`

Contains all logic for the permissions system. Handlers negotiation between permission handlers, adding and removing permission handlers and interacting with the default permissions handler

##  For permission plugins:
- Added `IPermissionsHandler`
- Added `Plugin.RegisterPermissionsHandler(IPermissionsHandler)`
- Added `Plugin.UnregisterPermissionsHandler(IPermissionsHandler)`

Permission plugins implement `IPermissionsHandler` and then register themselves using the function above. The only function added by this interface is `short CheckPermission(Player, string)` here is an example of an implementation of it: https://github.com/KarlOfDuty/SCPermissions/blob/f2918ec395d137c9a3e0b80ec7edc3a262c878ca/SCPermissions/SCPermissions.cs#L51

This is what permission plugins use to return a positive, neutral or negative response to the permissions manager when another plugin uses `Player.HasPermission()`.

Your plugin returns 0 if the player does not have the permission and 1 if they do have it. If any permission handler returns 1 the permission manager returns that the player has the permission, with one exception. 

The permission system also supports negative permissions. If any permission handler returns -1 the permission is denied regardless of if any other handler allowed it. 

## For normal plugins:
- `Added Player.HasPermission(string)`

Plugins can use this to check if a player has a specific permission, plugins should use the format `pluginname.permissionname` for their permission names in order to not conflict with other plugins. Here is an example: <https://github.com/KarlOfDuty/VPNShield/commit/374ade15a8a05b42f8adc8bc25796411bef4aaf4?diff=unified>

- Added `DefaultPermissionsHandler`
- Added `Plugin.AddDefaultPermission(string)`
- Added `Plugin.RemoveDefaultPermission(string)`

All plugins can register default permissions which are given to all players by default even if the server doesn't have a permissions plugin. These are handled by the `DefaultPermissionsHandler` and other permissions handlers can cancel them out if needed just like with any other permissions handler.