### PR TITLE
Added settable weapon sound effect

### DIFF
--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -72,6 +72,11 @@ namespace Smod2.API
 		CHEAT = 10
 	}
 
+	public enum WeaponType
+	{
+
+	}
+
 	public abstract class Player : ICommandSender
 	{
 		internal bool CallSetRoleEvent { get; set; }

--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -74,7 +74,12 @@ namespace Smod2.API
 
 	public enum WeaponType
 	{
-
+		COM15 = 0,
+		P90 = 1,
+		E11_STANDARD_RIFLE = 2,
+		MP7 = 3,
+		LOGICER = 4,
+		USP = 5,
 	}
 
 	public abstract class Player : ICommandSender

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -425,8 +425,9 @@ namespace Smod2.Events
 		public Vector SourcePosition { get; }
 		public Vector TargetPosition { get; }
 		public string TargetHitbox { get; }
+		public WeaponType? WeaponSound { get; set; }
 
-		public PlayerShootEvent(Player player, Player target, DamageType weapon, Vector sourcePosition, Vector targetPosition, string targetHitbox, bool spawnHitmarker = true, bool spawnBloodDecal = true) : base(player)
+		public PlayerShootEvent(Player player, Player target, DamageType weapon, Vector sourcePosition, Vector targetPosition, string targetHitbox, WeaponType weaponSound, bool spawnHitmarker = true, bool spawnBloodDecal = true) : base(player)
 		{
 			this.Target = target;
 			this.Weapon = weapon;
@@ -435,6 +436,7 @@ namespace Smod2.Events
 			this.SourcePosition = sourcePosition;
 			this.TargetPosition = targetPosition;
 			this.TargetHitbox = targetHitbox;
+			this.WeaponSound = weaponSound;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -426,8 +426,9 @@ namespace Smod2.Events
 		public Vector TargetPosition { get; }
 		public string TargetHitbox { get; }
 		public WeaponType? WeaponSound { get; set; }
+		public Vector Direction { get; set; }
 
-		public PlayerShootEvent(Player player, Player target, DamageType weapon, Vector sourcePosition, Vector targetPosition, string targetHitbox, WeaponType weaponSound, bool spawnHitmarker = true, bool spawnBloodDecal = true) : base(player)
+		public PlayerShootEvent(Player player, Player target, DamageType weapon, Vector sourcePosition, Vector targetPosition, string targetHitbox, WeaponType weaponSound, Vector direction, bool spawnHitmarker = true, bool spawnBloodDecal = true) : base(player)
 		{
 			this.Target = target;
 			this.Weapon = weapon;
@@ -437,6 +438,7 @@ namespace Smod2.Events
 			this.TargetPosition = targetPosition;
 			this.TargetHitbox = targetHitbox;
 			this.WeaponSound = weaponSound;
+			this.Direction = direction;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)


### PR DESCRIPTION
If it is null, the shoot animation/sound is not played but the hitmarker is still sent to the shooter.
Otherwise, if the weapon effects are cached (user has equipped weapon at least once that round, can be forced using plugin magic on `WeaponManager.NetworkcurWeapon`), it will play that weapon's sound effect instead of the held weapon's sound effect.

Sorry for multiple MRs in 24h, thought of this just a few hours after last MR.