### PR TITLE
PlayerThrowGrenadeEvent improvements

### DIFF
--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Smod2.Commands;
 
 namespace Smod2.API
@@ -82,6 +83,12 @@ namespace Smod2.API
 		USP = 5,
 	}
 
+	public enum GrenadeType
+	{
+		FRAG_GRENADE = 0,
+		FLASHBANG = 1
+	}
+
 	public abstract class Player : ICommandSender
 	{
 		internal bool CallSetRoleEvent { get; set; }
@@ -130,6 +137,8 @@ namespace Smod2.API
 		public abstract Vector GetRotation();
 		public abstract void SendConsoleMessage(string message, string color = "green");
 		public abstract void Infect(float time);
+		public abstract void ThrowGrenade(GrenadeType grenadeType, bool isCustomDirection, Vector direction, bool isEnvironmentallyTriggered, Vector position, bool isCustomForce, float throwForce, bool slowThrow = false);
+		[Obsolete("Use the overload with GrenadeType instead of ItemType", true)]
 		public abstract void ThrowGrenade(ItemType grenadeType, bool isCustomDirection, Vector direction, bool isEnvironmentallyTriggered, Vector position, bool isCustomForce, float throwForce, bool slowThrow = false);
 		public abstract bool GetBypassMode();
 		public abstract string GetAuthToken();

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -308,15 +308,19 @@ namespace Smod2.Events
 
 	public class PlayerThrowGrenadeEvent : PlayerEvent
 	{
-		public ItemType GrenadeType { get; }
-		public Vector Direction { get; }
-		public bool SlowThrow { get; }
+		public GrenadeType GrenadeType { get; set; }
+		public Vector Direction { get; set; }
+		public bool SlowThrow { get; set; }
+		public bool RemoveItem { get; set; }
+		public bool Allow { get; set; }
 
-		public PlayerThrowGrenadeEvent(Player player, ItemType grenadeType, Vector direction, bool slowThrow) : base(player)
+		public PlayerThrowGrenadeEvent(Player player, GrenadeType grenadeType, Vector direction, bool slowThrow, bool removeItem, bool allow) : base(player)
 		{
 			this.GrenadeType = grenadeType;
 			this.Direction = direction;
 			this.SlowThrow = slowThrow;
+			this.Allow = allow;
+			this.RemoveItem = removeItem;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)

--- a/Smod2/Smod2/PluginManager.cs
+++ b/Smod2/Smod2/PluginManager.cs
@@ -24,8 +24,8 @@ namespace Smod2
 	public class PluginManager
 	{
 		public static readonly int SMOD_MAJOR = 3;
-		public static readonly int SMOD_MINOR = 3;
-		public static readonly int SMOD_REVISION = 1;
+		public static readonly int SMOD_MINOR = 4;
+		public static readonly int SMOD_REVISION = 0;
 		public static readonly string SMOD_BUILD = "A";
 
 		public static readonly string DEPENDENCY_FOLDER = "dependencies";


### PR DESCRIPTION
Made every property in `PlayerThrowGrenadeEvent` settable and added property bools `Allow` and `RemoveItem`. If allow is false, the thrower still sees the grenade thrown and the animation plays. However, the grenade does not detonate, it just sits there. Also note that `Allow` does not halt execution, so the item will still be removed (assuming `RemoveItem` is `true`).

Also added enum `GrenadeType` because there were a lot of custom `ItemType` to int conversions in Assembly-CSharp that could otherwise just be casting.

SCPDiscord is the only big plugin that uses `PlayerThrowGrenadeEvent` and it has to rebuild anyway, so I don't think changing this event will break many plugins, much less break them to a hard-to-repair state.

~~Ignore the version bump, my version wasn't right so I had to do a quick fix in order to test with someone who had to sleep soon.~~