### PR TITLE
Lang Rework

### DIFF
--- a/Smod2/Smod2/LangManager/LangManager.cs
+++ b/Smod2/Smod2/LangManager/LangManager.cs
@@ -1,248 +1,350 @@
-﻿using System;
+﻿using Smod2.Attributes;
 using Smod2.Lang;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using Smod2.Attributes;
 
 namespace Smod2
 {
-	public class LangManager
-	{
-		private Dictionary<string, Plugin> settings = new Dictionary<string, Plugin>();
-		private Dictionary<string, string> keyvalue = new Dictionary<string, string>();
-		private Dictionary<Plugin, Dictionary<string, FieldInfo>> langFields = new Dictionary<Plugin, Dictionary<string, FieldInfo>>();
-		private Dictionary<Plugin, Snapshot> snapshots = new Dictionary<Plugin, Snapshot>();
+    public class LangManager
+    {
+        private Dictionary<string, Settings> settings = new Dictionary<string, Settings>();
+        private Dictionary<Plugin, Dictionary<string, FieldInfo>> langFields = new Dictionary<Plugin, Dictionary<string, FieldInfo>>();
+        private Dictionary<Plugin, Snapshot> snapshots = new Dictionary<Plugin, Snapshot>();
 
-		private static LangManager singleton;
-		public static LangManager Manager
-		{
-			get
-			{
-				if (singleton == null)
-				{
-					singleton = new LangManager();
-				}
-				return singleton;
-			}
-		}
+        private Dictionary<string, Dictionary<string, string>> FileNameKeyValue = new Dictionary<string, Dictionary<string, string>>();
+        private Dictionary<Plugin, HashSet<string>> PluginKeys = new Dictionary<Plugin, HashSet<string>>(); // for rapid removal
 
-		public bool IsRegistered(Plugin plugin, string key)
-		{
-			bool isRegistered = false;
-			if (settings.ContainsKey(key))
-			{
-				if (settings[key] == plugin)
-				{
-					isRegistered = true;
-				}
-			}
+        private static LangManager singleton;
+        public static LangManager Manager
+        {
+            get
+            {
+                if (singleton == null)
+                {
+                    singleton = new LangManager();
+                }
+                return singleton;
+            }
+        }
 
-			return isRegistered;
-		}
+        public bool IsRegistered(Plugin plugin, string key)
+        {
+            bool isRegistered = false;
+            if (settings.ContainsKey(key))
+            {
+                isRegistered = settings[key].pluginFiles.ContainsKey(plugin);
+            }
 
-		public bool RegisterTranslation(Plugin plugin, LangSetting setting)
-		{
-			if (!settings.ContainsKey(setting.Key))
-			{
-				settings.Add(setting.Key, plugin);
-				if (PluginManager.Manager.GetDisabledPlugin(plugin.Details.id) != null)
-				{
-					snapshots[plugin].Settings.Add(setting);
-				}
-				
-				if (!keyvalue.ContainsKey(setting.Key))
-				{
-					keyvalue.Add(setting.Key, setting.Default);
-					File.AppendAllText(Directory.GetCurrentDirectory() + "/./sm_translations/" + setting.Filename + ".txt", setting.Key.ToLower() + ": " + setting.Default + System.Environment.NewLine);
-				}
-				else
-				{
-					PluginManager.Manager.Logger.Debug("LANG_MANAGER", setting.Key + " exists in translation files.");
-				}
-			}
-			else
-			{
-				PluginManager.Manager.Logger.Warn("LANG_MANAGER", plugin.ToString() + " is trying to register a duplicate setting: " + setting.Key);
-				return false;
-			}
+            return isRegistered;
+        }
 
-			return true;
-		}
+        public bool IsRegistered(Plugin plugin, string key, string file)
+        {
+            bool isRegistered = false;
+            if (settings.ContainsKey(key))
+            {
+                if (settings[key].pluginFiles.ContainsKey(plugin))
+                {
+                    isRegistered = settings[key].pluginFiles[plugin].Contains(file);
+                }
+            }
 
-		public string GetTranslation(string key)
-		{
-			if (keyvalue.ContainsKey(key.ToUpper()))
-			{
-				return keyvalue[key.ToUpper()];
-			}
-			
-			return "NO_TRANSLATION";
-		}
+            return isRegistered;
+        }
 
-		public void RegisterPlugin(Plugin plugin)
-		{
-			if (!snapshots.ContainsKey(plugin))
-			{
-				snapshots.Add(plugin, new Snapshot());
-				RegisterAttributes(plugin);
-			}
-			else
-			{
-				Snapshot snapshot = snapshots[plugin];
-				if (!snapshot.Enabled)
-				{
-					return;
-				}
-				
-				foreach (LangSetting setting in snapshot.Settings)
-				{
-					RegisterTranslation(plugin, setting);
-				}
+        public bool RegisterTranslation(Plugin plugin, LangSetting setting)
+        {
+            if (settings.ContainsKey(setting.Key))
+            {
+                if (settings[setting.Key].pluginFiles.ContainsKey(plugin))
+                {
+                    if (settings[setting.Key].pluginFiles[plugin].Contains(setting.Filename))
+                    {
+                        PluginManager.Manager.Logger.Warn("LANG_MANAGER", plugin.ToString() + $" is trying to register a duplicate setting: '{setting.Key}'");
+                        return false;
+                    }
+                    else if (settings[setting.Key].fileLang.ContainsKey(setting.Filename))
+                    {
+                        PluginManager.Manager.Logger.Warn("LANG_MANAGER", plugin.ToString() + $" is typing to register a duplicate settings: '{setting.Key}' in one file '{setting.Filename}'");
+                        return false;
+                    }
+                    else
+                    {
+                        settings[setting.Key].pluginFiles[plugin].Add(setting.Filename);
+                        settings[setting.Key].fileLang.Add(setting.Filename, setting.Default);
+                    }
+                }
+                else
+                {
+                    settings[setting.Key].pluginFiles.Add(plugin, new List<string> { { setting.Filename } });
+                }
+            }
+            else
+            {
+                settings.Add(setting.Key, new Settings(plugin, setting.Filename, setting.Default));
+            }
 
-				snapshot.Enabled = false;
-			}
-		}
-		
-		public void UnregisterPlugin(Plugin plugin)
-		{
-			List<string> pluginKeys = new List<string>();
-			foreach (KeyValuePair<string, Plugin> setting in settings)
-			{
-				if (plugin == setting.Value)
-				{
-					pluginKeys.Add(setting.Key);
-				}
-			}
+            if (PluginManager.Manager.GetDisabledPlugin(plugin.Details.id) != null)
+            {
+                snapshots[plugin].Settings.Add(setting);
+            }
 
-			foreach (string key in pluginKeys)
-			{
-				settings.Remove(key);
-				keyvalue.Remove(key);
-			}
+            if(PluginKeys.ContainsKey(plugin))
+            {
+                if(!PluginKeys[plugin].Contains(setting.Key))
+                {
+                    PluginKeys[plugin].Add(setting.Key);
+                }
+            }
+            else
+            {
+                PluginKeys.Add(plugin, new HashSet<string> { { setting.Key } });
+            }
 
-			snapshots[plugin].Enabled = true;
-		}
-		
-		public void RegisterAttributes(Plugin plugin)
-		{
-			Type type = plugin.GetType();
+            if (FileNameKeyValue.ContainsKey(setting.Filename))
+            {
+                if (!FileNameKeyValue[setting.Filename].ContainsKey(setting.Key))
+                {
+                    File.AppendAllText(Directory.GetCurrentDirectory() + "/./sm_translations/" + setting.Filename + ".txt", setting.Key + ": " + setting.Default + System.Environment.NewLine);
+                }
+                else
+                {
+                    PluginManager.Manager.Logger.Debug("LANG_MANAGER", $"'{setting.Key}' exists in translation files.");
+                    settings[setting.Key].fileLang[setting.Filename] = FileNameKeyValue[setting.Filename][setting.Key];
+                }
 
-			const BindingFlags allMembers = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
-			foreach (FieldInfo field in type.GetFields(allMembers))
-			{
-				LangOption langOption = field.GetCustomAttribute<LangOption>();
-				if (langOption != null)
-				{
-					string key = langOption.Key ?? PluginManager.ToUpperSnakeCase(field.Name);
+            }
+            else
+            {
+                File.AppendAllText(Directory.GetCurrentDirectory() + "/./sm_translations/" + setting.Filename + ".txt", setting.Key + ": " + setting.Default + System.Environment.NewLine);
+            }
 
-					string file = plugin.Details.langFile;
-					if (file == null)
-					{
-						PluginManager.Manager.Logger.Error("LANG_MANAGER",  $"{plugin} is trying to register attribute lang {field.Name}, but does not have {nameof(PluginDetails.langFile)} in its {nameof(PluginDetails)} set.");
-						return;
-					}
+            return true;
+        }
 
-					if (string.IsNullOrWhiteSpace(key))
-					{
-						PluginManager.Manager.Logger.Error("LANG_MANAGER", $"{plugin} is trying to register attribute lang {field.Name}, but it has no valid key. Is the variable all underscores with no config key overload?");
-						continue;
-					}
+        public string GetTranslation(Plugin plugin, string key)
+        {
+            if (settings.ContainsKey(key))
+            {
+                if(settings[key].pluginFiles.ContainsKey(plugin))
+                {
+                    string fileName = settings[key].pluginFiles[plugin][0];
+                    return settings[key].fileLang[fileName].Clone() as string;
+                }
+            }
 
-					if (field.FieldType != typeof(string))
-					{
-						PluginManager.Manager.Logger.Error("LANG_MANAGER", $"{plugin} is trying to register attribute lang {field.Name}, but the type ({field.FieldType}) is not a string.");
-						continue;
-					}
-					
-					if (!RegisterTranslation(plugin, new LangSetting(key, (string) field.GetValue(plugin),  file)))
-					{
-						// Failed register so it should not be registered to refresh every round restart.
-						PluginManager.Manager.Logger.Debug("LANG_MANAGER", $"Unable to register attribute translation {field.Name} from {plugin}.");
-						continue;
-					}
+            return null;
+        }
 
-					if (!langFields.ContainsKey(plugin))
-					{
-						langFields.Add(plugin, new Dictionary<string, FieldInfo>());
-					}
+        public string GetTranslation(Plugin plugin, string key, string file)
+        {
+            if (settings.ContainsKey(key))
+            {
+                if(settings[key].pluginFiles.ContainsKey(plugin))
+                {
+                    if(settings[key].pluginFiles[plugin].Contains(file))
+                    {
+                        return settings[key].fileLang[file].Clone() as string;
+                    }
+                }
+            }
 
-					langFields[plugin].Add(key, field);
-				}
-			}
-		}
+            return null;
+        }
 
-		public void RefreshAttributes(Plugin plugin)
-		{
-			if (!langFields.ContainsKey(plugin))
-			{
-				return;
-			}
+        public void RegisterPlugin(Plugin plugin)
+        {
+            if (!snapshots.ContainsKey(plugin))
+            {
+                snapshots.Add(plugin, new Snapshot());
+                RegisterAttributes(plugin);
+            }
+            else
+            {
+                Snapshot snapshot = snapshots[plugin];
+                if (!snapshot.Enabled)
+                {
+                    return;
+                }
 
-			foreach (KeyValuePair<string, FieldInfo> lang in langFields[plugin])
-			{
-				lang.Value.SetValue(plugin, plugin.GetTranslation(lang.Key));
-			}
-		}
+                foreach (LangSetting setting in snapshot.Settings)
+                {
+                    RegisterTranslation(plugin, setting);
+                }
 
-		public LangManager()
-		{
-			string smTranslationPath = Directory.GetCurrentDirectory() + "/./sm_translations/";
-			if (!Directory.Exists(smTranslationPath))
-			{
-				Directory.CreateDirectory(smTranslationPath);
-			}
+                snapshot.Enabled = false;
+            }
+        }
 
-			DirectoryInfo dir = new DirectoryInfo(smTranslationPath);
-			foreach (FileInfo file in dir.GetFiles("*.txt"))
-			{
-				foreach (string line in File.ReadAllLines(file.FullName))
-				{
-					if (line.Length == 0 || line[0] == '#' || line.StartsWith("//"))
-					{
-						continue;
-					}
-					
-					string[] keyvalue = line.Split(':');
-					if (keyvalue.Length < 2)
-					{
-						PluginManager.Manager.Logger.Error("LANG_MANAGER", "Cant load keyvalue from " + file.Name + ": " + line);
-						continue;
-					}
+        public void UnregisterPlugin(Plugin plugin)
+        {
+            if(PluginKeys.ContainsKey(plugin))
+            {
+                HashSet<string> keys = PluginKeys[plugin];
 
-					keyvalue[1] = keyvalue[1].Substring(1);
-					// If the value contains a colon in it, make sure it isn't cut off
-					if (keyvalue.Length > 2)
-					{
-						for (int i = 2; i < keyvalue.Length; i++)
-						{
-							keyvalue[1] += ":" + keyvalue[i];
-						}
-					}
+                foreach(string key in keys)
+                {
+                    if(settings.ContainsKey(key))
+                    {
+                        string[] files = settings[key].pluginFiles[plugin].ToArray(); // to avoid getting an error when deleting and reading data
 
-					string key = keyvalue[0].ToUpper();
-					if (this.keyvalue.ContainsKey(key))
-					{
-						PluginManager.Manager.Logger.Error("LANG_MANAGER", "Duplicate key detected: " + keyvalue[0]);
-					}
-					else
-					{
-						this.keyvalue.Add(key, keyvalue[1]);
-						PluginManager.Manager.Logger.Debug("LANG_MANAGER", line);
-					}
-				}
-			}
-		}
-		
-		private class Snapshot
-		{
-			public List<LangSetting> Settings { get; }
-			public bool Enabled { get; set; }
+                        foreach(string file in files)
+                        {
+                            settings[key].fileLang.Remove(file);
+                        }
 
-			public Snapshot()
-			{
-				Settings = new List<LangSetting>();
-			}
-		}
-	}
+                        settings[key].pluginFiles.Remove(plugin);
+                    }
+                }
+
+                PluginKeys.Remove(plugin);
+
+            }
+
+            snapshots[plugin].Enabled = true;
+        }
+
+        public void RegisterAttributes(Plugin plugin)
+        {
+            Type type = plugin.GetType();
+
+            const BindingFlags allMembers = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+            foreach (FieldInfo field in type.GetFields(allMembers))
+            {
+                LangOption langOption = field.GetCustomAttribute<LangOption>();
+                if (langOption != null)
+                {
+                    string key = langOption.Key ?? PluginManager.ToUpperSnakeCase(field.Name);
+
+                    string file = plugin.Details.langFile;
+                    if (file == null)
+                    {
+                        PluginManager.Manager.Logger.Error("LANG_MANAGER", $"{plugin} is trying to register attribute lang {field.Name}, but does not have {nameof(PluginDetails.langFile)} in its {nameof(PluginDetails)} set.");
+                        return;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(key))
+                    {
+                        PluginManager.Manager.Logger.Error("LANG_MANAGER", $"{plugin} is trying to register attribute lang {field.Name}, but it has no valid key. Is the variable all underscores with no config key overload?");
+                        continue;
+                    }
+
+                    if (field.FieldType != typeof(string))
+                    {
+                        PluginManager.Manager.Logger.Error("LANG_MANAGER", $"{plugin} is trying to register attribute lang {field.Name}, but the type ({field.FieldType}) is not a string.");
+                        continue;
+                    }
+
+                    if (!RegisterTranslation(plugin, new LangSetting(key, (string)field.GetValue(plugin), file)))
+                    {
+                        // Failed register so it should not be registered to refresh every round restart.
+                        PluginManager.Manager.Logger.Debug("LANG_MANAGER", $"Unable to register attribute translation {field.Name} from {plugin}.");
+                        continue;
+                    }
+
+                    if (!langFields.ContainsKey(plugin))
+                    {
+                        langFields.Add(plugin, new Dictionary<string, FieldInfo>());
+                    }
+
+                    langFields[plugin].Add(key, field);
+                }
+            }
+        }
+
+        public void RefreshAttributes(Plugin plugin)
+        {
+            if (!langFields.ContainsKey(plugin))
+            {
+                return;
+            }
+
+            foreach (KeyValuePair<string, FieldInfo> lang in langFields[plugin])
+            {
+                lang.Value.SetValue(plugin, plugin.GetTranslation(lang.Key, plugin.Details.langFile));
+            }
+        }
+
+        public LangManager()
+        {
+            string smTranslationPath = Directory.GetCurrentDirectory() + "/./sm_translations/";
+            if (!Directory.Exists(smTranslationPath))
+            {
+                Directory.CreateDirectory(smTranslationPath);
+            }
+
+            DirectoryInfo dir = new DirectoryInfo(smTranslationPath);
+            foreach (FileInfo file in dir.GetFiles("*.txt"))
+            {
+                foreach (string line in File.ReadAllLines(file.FullName))
+                {
+                    if (line.Length == 0 || line[0] == '#' || line.StartsWith("//"))
+                    {
+                        continue;
+                    }
+
+                    string[] keyvalue = line.Split(':');
+                    if (keyvalue.Length < 2)
+                    {
+                        PluginManager.Manager.Logger.Error("LANG_MANAGER", "Cant load keyvalue from " + file.Name + ": " + line);
+                        continue;
+                    }
+
+                    keyvalue[1] = keyvalue[1].Substring(1);
+                    // If the value contains a colon in it, make sure it isn't cut off
+                    if (keyvalue.Length > 2)
+                    {
+                        for (int i = 2; i < keyvalue.Length; i++)
+                        {
+                            keyvalue[1] += ":" + keyvalue[i];
+                        }
+                    }
+
+                    string key = keyvalue[0].ToLower();
+                    string filename = file.Name.Substring(0, file.Name.IndexOf('.'));
+
+                    if (FileNameKeyValue.ContainsKey(filename))
+                    {
+                        if (FileNameKeyValue[filename].ContainsKey(key))
+                            PluginManager.Manager.Logger.Error("LANG_MANAGER", "Duplicate key detected: " + keyvalue[0]);
+                        else
+                        {
+                            FileNameKeyValue[filename].Add(key, keyvalue[1]);
+                            PluginManager.Manager.Logger.Debug("LANG_MANAGER", line);
+                        }
+                    }
+                    else
+                    {
+                        FileNameKeyValue.Add(filename, new Dictionary<string, string> { { key, keyvalue[1] } });
+                        PluginManager.Manager.Logger.Debug("LANG_MANAGER", line);
+                    }
+                }
+            }
+        }
+
+        private class Snapshot
+        {
+            public List<LangSetting> Settings { get; }
+            public bool Enabled { get; set; }
+
+            public Snapshot()
+            {
+                Settings = new List<LangSetting>();
+            }
+        }
+
+        private class Settings
+        {
+            public Dictionary<Plugin, List<string>> pluginFiles;
+            public Dictionary<string, string> fileLang;
+
+            public Settings(Plugin plugin, string filename, string lang)
+            {
+                this.pluginFiles = new Dictionary<Plugin, List<string>> { { plugin, new List<string> { { filename } } } };
+                this.fileLang = new Dictionary<string, string> { { filename, lang } };
+            }
+        }
+    }
 }

--- a/Smod2/Smod2/LangManager/LangOption.cs
+++ b/Smod2/Smod2/LangManager/LangOption.cs
@@ -10,11 +10,11 @@ namespace Smod2.Lang
 		public LangOption() { }
 		public LangOption(string key)
 		{
-			if (string.IsNullOrWhiteSpace(key))
-			{
-				throw new ArgumentException("Lang keys cannot be null, whitespace, or empty.", nameof(key));
-			}
-			
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentException("Lang keys cannot be null, whitespace, or empty.", nameof(key));
+            }
+
 			Key = key;
 		}
 	}

--- a/Smod2/Smod2/LangManager/LangSetting.cs
+++ b/Smod2/Smod2/LangManager/LangSetting.cs
@@ -9,7 +9,7 @@ namespace Smod2.Lang
 		{
 			get
 			{
-				return key;
+				return key.ToLower();
 			}
 		}
 

--- a/Smod2/Smod2/PluginManager.cs
+++ b/Smod2/Smod2/PluginManager.cs
@@ -25,8 +25,8 @@ namespace Smod2
 	public class PluginManager
 	{
 		public static readonly int SMOD_MAJOR = 3;
-		public static readonly int SMOD_MINOR = 4;
-		public static readonly int SMOD_REVISION = 1;
+		public static readonly int SMOD_MINOR = 5;
+		public static readonly int SMOD_REVISION = 0;
 
 		public static readonly string SMOD_BUILD = "A";
 


### PR DESCRIPTION
I added the ability to use multiple keys in different files, presently you cannot use for example лун `return` in `Lang1.txt` and `Lang2.txt` files.

Also, it will break the receipt of the transfer directly through `LangManager.Manager.GetTranslation` (added plugin in arguments).