### PR TITLE
3.5.1-K

### DIFF
--- a/Smod2/Smod2/API/Item.cs
+++ b/Smod2/Smod2/API/Item.cs
@@ -1,4 +1,4 @@
-﻿namespace Smod2.API
+namespace Smod2.API
 {
 	public enum ItemType
 	{
@@ -56,5 +56,7 @@
 		public abstract void SetKinematic(bool doPhysics);
 		public abstract bool GetKinematic();
 		public abstract object GetComponent();
+		public abstract bool IsWeapon();
+		public abstract Weapon ToWeapon();
 	}
 }

--- a/Smod2/Smod2/API/Item.cs
+++ b/Smod2/Smod2/API/Item.cs
@@ -26,7 +26,7 @@ namespace Smod2.API
 		E11_STANDARD_RIFLE = 20,
 		P90 = 21,
 		DROPPED_5 = 22,
-		MP4 = 23,
+		MP7 = 23,
 		LOGICER = 24,
 		FRAG_GRENADE = 25,
 		FLASHBANG = 26,

--- a/Smod2/Smod2/API/Item.cs
+++ b/Smod2/Smod2/API/Item.cs
@@ -56,7 +56,7 @@ namespace Smod2.API
 		public abstract void SetKinematic(bool doPhysics);
 		public abstract bool GetKinematic();
 		public abstract object GetComponent();
-		public abstract bool IsWeapon();
+		public abstract bool IsWeapon { get; }
 		public abstract Weapon ToWeapon();
 	}
 }

--- a/Smod2/Smod2/API/Map.cs
+++ b/Smod2/Smod2/API/Map.cs
@@ -20,6 +20,8 @@ namespace Smod2.API
 		public abstract bool WarheadDetonated { get; }
 		public abstract bool LCZDecontaminated { get; }
 		public abstract void SpawnItem(ItemType type, Vector position, Vector rotation);
+		public abstract void SpawnItem(WeaponType type, float Ammo, WeaponSight Sight, WeaponBarrel Barrel, WeaponOther Other, Vector pos, Vector rotation);
+		public abstract void SpawnItem(AmmoType type, float Ammo, Vector position, Vector rotation);
 		/// <summary>  
 		/// Note: When FemurBreaker is enabled, SCP-106 can't be contained. This might break the lure configs and mechanism.
 		/// </summary> 

--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -44,10 +44,10 @@ namespace Smod2.API
 
 	public enum AmmoType
 	{
-		NONE = -1,
+		NONE = -1,     // Has no base in-game.
 		DROPPED_5 = 0, // Epsilon-11 Standard Rifle (Type 0)
 		DROPPED_7 = 1, // MP7, Logicer (Type 1)
-		DROPPED_9 = 2, // COM15, P90 (Type 2)
+		DROPPED_9 = 2  // COM15, P90 (Type 2)
 	}
 
 	public enum RadioStatus

--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -131,7 +131,7 @@ namespace Smod2.API
 		public abstract void ThrowGrenade(GrenadeType grenadeType, bool isCustomDirection, Vector direction, bool isEnvironmentallyTriggered, Vector position, bool isCustomForce, float throwForce, bool slowThrow = false);
 		[Obsolete("Use the overload with GrenadeType instead of ItemType", true)]
 		public abstract void ThrowGrenade(ItemType grenadeType, bool isCustomDirection, Vector direction, bool isEnvironmentallyTriggered, Vector position, bool isCustomForce, float throwForce, bool slowThrow = false);
-		public abstract bool GetBypassMode();
+		public abstract bool BypassMode { get; set; }
 		public abstract string GetAuthToken();
 		public abstract void HideTag(bool enable);
 		public abstract void PersonalBroadcast(uint duration, string message, bool isMonoSpaced);

--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -136,6 +136,8 @@ namespace Smod2.API
 		public abstract void HideTag(bool enable);
 		public abstract void PersonalBroadcast(uint duration, string message, bool isMonoSpaced);
 		public abstract void PersonalClearBroadcasts();
+		public abstract bool Muted { get; set; }
+		public abstract bool IntercomMuted { get; set; }
 		public bool HasPermission(string permissionName)
 		{
 			return PluginManager.Manager.PermissionsManager.CheckPermission(this, permissionName);

--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Smod2.Commands;
 
@@ -46,7 +46,8 @@ namespace Smod2.API
 	{
 		DROPPED_5 = 0, // Epsilon-11 Standard Rifle (Type 0)
 		DROPPED_7 = 1, // MP7, Logicer (Type 1)
-		DROPPED_9 = 2 // COM15, P90 (Type 2)
+		DROPPED_9 = 2, // COM15, P90 (Type 2)
+		NONE = 3
 	}
 
 	public enum RadioStatus
@@ -71,16 +72,6 @@ namespace Smod2.API
 		USE_TESLAGATE = 8,
 		USE_ELEVATOR = 9,
 		CHEAT = 10
-	}
-
-	public enum WeaponType
-	{
-		COM15 = 0,
-		P90 = 1,
-		E11_STANDARD_RIFLE = 2,
-		MP7 = 3,
-		LOGICER = 4,
-		USP = 5,
 	}
 
 	public enum GrenadeType

--- a/Smod2/Smod2/API/Player.cs
+++ b/Smod2/Smod2/API/Player.cs
@@ -44,10 +44,10 @@ namespace Smod2.API
 
 	public enum AmmoType
 	{
+		NONE = -1,
 		DROPPED_5 = 0, // Epsilon-11 Standard Rifle (Type 0)
 		DROPPED_7 = 1, // MP7, Logicer (Type 1)
 		DROPPED_9 = 2, // COM15, P90 (Type 2)
-		NONE = 3
 	}
 
 	public enum RadioStatus

--- a/Smod2/Smod2/API/Server.cs
+++ b/Smod2/Smod2/API/Server.cs
@@ -30,6 +30,7 @@ namespace Smod2.API
 		public abstract List<Player> GetPlayers(Role role);
 		public abstract List<Player> GetPlayers(Role[] roles);
 		public abstract List<Player> GetPlayers(Team team);
+		public abstract List<Player> GetPlayers(Predicate<Player> predicate);
 		public abstract Player GetPlayer(int playerId);
 		public abstract List<Connection> GetConnections(string filter = "");
 		public abstract List<TeamRole> GetRoles(string filter = "");

--- a/Smod2/Smod2/API/Server.cs
+++ b/Smod2/Smod2/API/Server.cs
@@ -30,7 +30,6 @@ namespace Smod2.API
 		public abstract List<Player> GetPlayers(Role role);
 		public abstract List<Player> GetPlayers(Role[] roles);
 		public abstract List<Player> GetPlayers(Team team);
-		public abstract List<Player> GetPlayers(Predicate<Player> predicate);
 		public abstract Player GetPlayer(int playerId);
 		public abstract List<Connection> GetConnections(string filter = "");
 		public abstract List<TeamRole> GetRoles(string filter = "");

--- a/Smod2/Smod2/API/Weapon.cs
+++ b/Smod2/Smod2/API/Weapon.cs
@@ -6,15 +6,6 @@ using System.Threading.Tasks;
 
 namespace Smod2.API
 {
-
-	public enum AttachmentType
-	{
-		NONE = 0,
-		SIGHT = 1,
-		BARREL = 2,
-		OTHER = 3,
-	}
-
 	public enum WeaponType
 	{
 		COM15 = (int)ItemType.COM15,
@@ -39,7 +30,7 @@ namespace Smod2.API
 	public enum WeaponBarrel
 	{
 		NONE = 0,
-		SUPRESSOR = 1,
+		SUPPRESSOR = 1,
 		OIL_FILTER = 2,
 		MUZZLE_BREAK = 3,
 		HEAVY_BARREL = 4,
@@ -55,17 +46,23 @@ namespace Smod2.API
 		GYROSCOPIC_STABILIZER = 4,
 	}
 
+	public enum AttachmentType
+	{
+		NONE = 0,
+		SIGHT = 1,
+		BARREL = 2,
+		OTHER = 3,
+	}
+
 	public abstract class Weapon
 	{
 		public abstract WeaponType WeaponType { get; }
-		public abstract WeaponSight GetSight();
-		public abstract WeaponBarrel GetBarrel();
-		public abstract WeaponOther GetOther();
-		public abstract void SetAttachments(WeaponSight Sight, WeaponBarrel Barrel, WeaponOther Other);
-		public abstract void SetAmountOfAmmoInClip(float ammo);
-		public abstract float GetAmmoLeftInClip();
-		public abstract int GetMaxClipSize();
-		public abstract AmmoType GetAmmoType();
+		public abstract WeaponSight Sight { get; set; }
+		public abstract WeaponBarrel Barrel { get; set; }
+		public abstract WeaponOther Other { get; set; }
+		public abstract float AmmoInClip { get; set; }
+		public abstract int MaxClipSize { get; }
+		public abstract AmmoType AmmoType { get; }
 		public abstract object GetComponent();
 	}
 }

--- a/Smod2/Smod2/API/Weapon.cs
+++ b/Smod2/Smod2/API/Weapon.cs
@@ -6,9 +6,19 @@ namespace Smod2.API
 		MICROHID = (int)ItemType.MICROHID,
 		E11_STANDARD_RIFLE = (int)ItemType.E11_STANDARD_RIFLE,
 		P90 = (int)ItemType.P90,
-		MP4 = (int)ItemType.MP4,
+		MP7 = (int)ItemType.MP7,
 		LOGICER = (int)ItemType.LOGICER,
 		USP = (int)ItemType.USP
+	}
+
+	public enum WeaponSound
+	{
+		COM15 = 0,
+		P90 = 1,
+		E11_STANDARD_RIFLE = 2,
+		MP7 = 3,
+		LOGICER = 4,
+		USP = 5,
 	}
 
 	public enum WeaponSight
@@ -57,6 +67,7 @@ namespace Smod2.API
 		public abstract float AmmoInClip { get; set; }
 		public abstract int MaxClipSize { get; }
 		public abstract AmmoType AmmoType { get; }
+		public abstract DamageType DamageType { get; }
 		public abstract object GetComponent();
 	}
 }

--- a/Smod2/Smod2/API/Weapon.cs
+++ b/Smod2/Smod2/API/Weapon.cs
@@ -69,5 +69,6 @@ namespace Smod2.API
 		public abstract AmmoType AmmoType { get; }
 		public abstract DamageType DamageType { get; }
 		public abstract object GetComponent();
+		public abstract Item ToItem();
 	}
 }

--- a/Smod2/Smod2/API/Weapon.cs
+++ b/Smod2/Smod2/API/Weapon.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Smod2.API
 {
 	public enum WeaponType
@@ -48,10 +42,10 @@ namespace Smod2.API
 
 	public enum AttachmentType
 	{
-		NONE = 0,
-		SIGHT = 1,
-		BARREL = 2,
-		OTHER = 3,
+		NONE = -1,
+		SIGHT = 0,
+		BARREL = 1,
+		OTHER = 2,
 	}
 
 	public abstract class Weapon

--- a/Smod2/Smod2/API/Weapon.cs
+++ b/Smod2/Smod2/API/Weapon.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Smod2.API
+{
+
+	public enum AttachmentType
+	{
+		NONE = 0,
+		SIGHT = 1,
+		BARREL = 2,
+		OTHER = 3,
+	}
+
+	public enum WeaponType
+	{
+		COM15 = (int)ItemType.COM15,
+		MICROHID = (int)ItemType.MICROHID,
+		E11_STANDARD_RIFLE = (int)ItemType.E11_STANDARD_RIFLE,
+		P90 = (int)ItemType.P90,
+		MP4 = (int)ItemType.MP4,
+		LOGICER = (int)ItemType.LOGICER,
+		USP = (int)ItemType.USP,
+	}
+
+	public enum WeaponSight
+	{
+		NONE = 0,
+		RED_DOT = 1,
+		HOLO_SIGHT = 2,
+		NIGHT_VISION = 3,
+		SNIPER_SCOPE = 4,
+		COLLIMATOR = 5,
+	}
+
+	public enum WeaponBarrel
+	{
+		NONE = 0,
+		SUPRESSOR = 1,
+		OIL_FILTER = 2,
+		MUZZLE_BREAK = 3,
+		HEAVY_BARREL = 4,
+		MUZZLE_BOOSTER = 5,
+	}
+
+	public enum WeaponOther
+	{
+		NONE = 0,
+		FLASHLIGHT = 1,
+		LASER = 2,
+		AMMO_COUNTER = 3,
+		GYROSCOPIC_STABILIZER = 4,
+	}
+
+	public abstract class Weapon
+	{
+		public abstract WeaponType WeaponType { get; }
+		public abstract WeaponSight GetSight();
+		public abstract WeaponBarrel GetBarrel();
+		public abstract WeaponOther GetOther();
+		public abstract void SetAttachments(WeaponSight Sight, WeaponBarrel Barrel, WeaponOther Other);
+		public abstract void SetAmountOfAmmoInClip(float ammo);
+		public abstract float GetAmmoLeftInClip();
+		public abstract int GetMaxClipSize();
+		public abstract AmmoType GetAmmoType();
+		public abstract object GetComponent();
+	}
+}

--- a/Smod2/Smod2/API/Weapon.cs
+++ b/Smod2/Smod2/API/Weapon.cs
@@ -8,7 +8,7 @@ namespace Smod2.API
 		P90 = (int)ItemType.P90,
 		MP4 = (int)ItemType.MP4,
 		LOGICER = (int)ItemType.LOGICER,
-		USP = (int)ItemType.USP,
+		USP = (int)ItemType.USP
 	}
 
 	public enum WeaponSight
@@ -18,7 +18,7 @@ namespace Smod2.API
 		HOLO_SIGHT = 2,
 		NIGHT_VISION = 3,
 		SNIPER_SCOPE = 4,
-		COLLIMATOR = 5,
+		COLLIMATOR = 5
 	}
 
 	public enum WeaponBarrel
@@ -28,7 +28,7 @@ namespace Smod2.API
 		OIL_FILTER = 2,
 		MUZZLE_BREAK = 3,
 		HEAVY_BARREL = 4,
-		MUZZLE_BOOSTER = 5,
+		MUZZLE_BOOSTER = 5
 	}
 
 	public enum WeaponOther
@@ -37,7 +37,7 @@ namespace Smod2.API
 		FLASHLIGHT = 1,
 		LASER = 2,
 		AMMO_COUNTER = 3,
-		GYROSCOPIC_STABILIZER = 4,
+		GYROSCOPIC_STABILIZER = 4
 	}
 
 	public enum AttachmentType
@@ -45,7 +45,7 @@ namespace Smod2.API
 		NONE = -1,
 		SIGHT = 0,
 		BARREL = 1,
-		OTHER = 2,
+		OTHER = 2
 	}
 
 	public abstract class Weapon

--- a/Smod2/Smod2/EventSystem/EventHandlers/EnviromentEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/EnviromentEventHandlers.cs
@@ -1,4 +1,4 @@
-﻿using Smod2.Events;
+using Smod2.Events;
 
 namespace Smod2.EventHandlers
 {
@@ -73,5 +73,21 @@ namespace Smod2.EventHandlers
 		/// Called when a C.A.S.S.I.E. announcement gets added for an SCP death.
 		/// </summary>
 		void OnScpDeathAnnouncement(ScpDeathAnnouncementEvent ev);
+	}
+
+	public interface IEventHandlerCassieCustomAnnouncement : IEventHandler
+	{
+		/// <summary>  
+		///  This event handler will call when a custom announcement is made. (AKA through the api for example.)
+		/// </summary> 
+		void OnCassieCustomAnnouncement(CassieCustomAnnouncementEvent ev);
+	}
+
+	public interface IEventHandlerCassieTeamAnnouncement : IEventHandler
+	{
+		/// <summary>  
+		///  This event handler will call when NTF respawns.
+		/// </summary> 
+		void OnCassieTeamAnnouncement(CassieTeamAnnouncementEvent ev);
 	}
 }

--- a/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
@@ -29,7 +29,13 @@ namespace Smod2.EventHandlers
 		/// </summary> 
 		void OnPlayerPickupItem(PlayerPickupItemEvent ev);
 	}
-
+	public interface IEventHandlerPlayerPickupItemEarly : IEventHandler
+	{
+		/// <summary>  
+		/// This is called when a player picks up an item.
+		/// </summary> 
+		void OnPlayerPickupItemEarly(PlayerPickupItemEarlyEvent ev);
+	}
 	public interface IEventHandlerPlayerPickupItemLate : IEventHandler
 	{
 		/// <summary>  
@@ -37,7 +43,6 @@ namespace Smod2.EventHandlers
 		/// </summary> 
 		void OnPlayerPickupItemLate(PlayerPickupItemLateEvent ev);
 	}
-
 	public interface IEventHandlerPlayerDropItem : IEventHandler
 	{
 		/// <summary>  
@@ -45,7 +50,13 @@ namespace Smod2.EventHandlers
 		/// </summary> 
 		void OnPlayerDropItem(PlayerDropItemEvent ev);
 	}
-
+	public interface IEventHandlerPlayerDropAllItems : IEventHandler
+	{
+		/// <summary>  
+		/// This is called when all of the item's are going to be dropped.
+		/// </summary> 
+		void OnPlayerDropAllItems(PlayerDropAllItemsEvent ev);
+	}
 	public interface IEventHandlerPlayerJoin : IEventHandler
 	{
 		/// <summary>  

--- a/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
@@ -25,21 +25,21 @@ namespace Smod2.EventHandlers
 	public interface IEventHandlerPlayerPickupItem : IEventHandler
 	{
 		/// <summary>  
-		/// This is called when a player picks up an item.
+		/// This is called when a player picks up an item and its deleted off of the ground and is NOT in their inventory.
 		/// </summary> 
 		void OnPlayerPickupItem(PlayerPickupItemEvent ev);
 	}
 	public interface IEventHandlerPlayerPickupItemEarly : IEventHandler
 	{
 		/// <summary>  
-		/// This is called when a player picks up an item.
+		/// This is called when a player picks up an item and its still on the ground.
 		/// </summary> 
 		void OnPlayerPickupItemEarly(PlayerPickupItemEarlyEvent ev);
 	}
 	public interface IEventHandlerPlayerPickupItemLate : IEventHandler
 	{
 		/// <summary>  
-		/// This is called after a player picks up an item.
+		/// This is called after a player picks up an item and is their inventory.
 		/// </summary> 
 		void OnPlayerPickupItemLate(PlayerPickupItemLateEvent ev);
 	}
@@ -53,7 +53,7 @@ namespace Smod2.EventHandlers
 	public interface IEventHandlerPlayerDropAllItems : IEventHandler
 	{
 		/// <summary>  
-		/// This is called when all of the item's are going to be dropped.
+		/// This is called when all of the items in a player's inventory are going to be dropped.
 		/// </summary> 
 		void OnPlayerDropAllItems(PlayerDropAllItemsEvent ev);
 	}

--- a/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
@@ -29,13 +29,7 @@ namespace Smod2.EventHandlers
 		/// </summary> 
 		void OnPlayerPickupItem(PlayerPickupItemEvent ev);
 	}
-	public interface IEventHandlerPlayerPickupItemEarly : IEventHandler
-	{
-		/// <summary>  
-		/// This is called when a player picks up an item and its still on the ground.
-		/// </summary> 
-		void OnPlayerPickupItemEarly(PlayerPickupItemEarlyEvent ev);
-	}
+
 	public interface IEventHandlerPlayerPickupItemLate : IEventHandler
 	{
 		/// <summary>  

--- a/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
@@ -39,7 +39,7 @@ namespace Smod2.EventHandlers
 	public interface IEventHandlerPlayerPickupItemLate : IEventHandler
 	{
 		/// <summary>  
-		/// This is called after a player picks up an item and is their inventory.
+		/// This is called after a player picks up an item and is in their inventory.
 		/// </summary> 
 		void OnPlayerPickupItemLate(PlayerPickupItemLateEvent ev);
 	}

--- a/Smod2/Smod2/EventSystem/EventHandlers/ServerRoundEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/ServerRoundEventHandlers.cs
@@ -1,5 +1,5 @@
 using Smod2.Events;
-
+using System;
 namespace Smod2.EventHandlers
 {
 	public interface IEventHandlerRoundStart : IEventHandler
@@ -26,28 +26,30 @@ namespace Smod2.EventHandlers
 		void OnConnect(ConnectEvent ev);
 	}
 
+	[Obsolete("Provides no information please use IEventHandlerPlayerLeave")]
 	public interface IEventHandlerDisconnect : IEventHandler
 	{
 		/// <summary>  
 		///  This is the event handler for disconnection events.
-		/// </summary> 
+		/// </summary>
 		void OnDisconnect(DisconnectEvent ev);
 	}
 
+	[Obsolete("Provides no information please use IEventHandlerPlayerLeave")]
 	public interface IEventHandlerLateDisconnect : IEventHandler
 	{
 		/// <summary>  
 		///  This is the event handler for disconnection events after the player has disconnected.
-		/// </summary> 
+		/// </summary>
 		void OnLateDisconnect(LateDisconnectEvent ev);
 	}
 
 	public interface IEventHandlerPlayerLeave : IEventHandler
 	{
 		/// <summary>  
-		///  This is called when OnDestroy() is called on QueryProcessor.
+		///  Called OnDestroy of QueryProcessor aka when a player leaves.
 		/// </summary> 
-		void OnPlayerLeave(PlayerLeaveEvent ev);
+		void OnPlayerLeave(OnPlayerLeaveEvent ev);
 	}
 
 	public interface IEventHandlerCheckRoundEnd : IEventHandler

--- a/Smod2/Smod2/EventSystem/EventHandlers/ServerRoundEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/ServerRoundEventHandlers.cs
@@ -1,4 +1,4 @@
-﻿using Smod2.Events;
+using Smod2.Events;
 
 namespace Smod2.EventHandlers
 {
@@ -104,6 +104,14 @@ namespace Smod2.EventHandlers
 		///  This event handler will call when the server scene changes
 		/// </summary> 
 		void OnSceneChanged(SceneChangedEvent ev);
+	}
+	
+	public interface IEventHandlerSetSeed : IEventHandler
+	{
+		/// <summary>  
+		///  This event handler will call when the seed for the round is being set
+		/// </summary> 
+		void OnSetSeed(SetSeedEvent ev);
 	}
 }
 

--- a/Smod2/Smod2/EventSystem/EventHandlers/ServerRoundEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/ServerRoundEventHandlers.cs
@@ -26,7 +26,6 @@ namespace Smod2.EventHandlers
 		void OnConnect(ConnectEvent ev);
 	}
 
-	[Obsolete("Provides no information please use IEventHandlerPlayerLeave")]
 	public interface IEventHandlerDisconnect : IEventHandler
 	{
 		/// <summary>  
@@ -49,7 +48,7 @@ namespace Smod2.EventHandlers
 		/// <summary>  
 		///  Called OnDestroy of QueryProcessor aka when a player leaves.
 		/// </summary> 
-		void OnPlayerLeave(OnPlayerLeaveEvent ev);
+		void PlayerLeaveEvent(PlayerLeaveEvent ev);
 	}
 
 	public interface IEventHandlerCheckRoundEnd : IEventHandler

--- a/Smod2/Smod2/EventSystem/EventHandlers/ServerRoundEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/ServerRoundEventHandlers.cs
@@ -48,7 +48,7 @@ namespace Smod2.EventHandlers
 		/// <summary>  
 		///  Called OnDestroy of QueryProcessor aka when a player leaves.
 		/// </summary> 
-		void PlayerLeaveEvent(PlayerLeaveEvent ev);
+		void OnPlayerLeave(PlayerLeaveEvent ev);
 	}
 
 	public interface IEventHandlerCheckRoundEnd : IEventHandler

--- a/Smod2/Smod2/EventSystem/EventHandlers/ServerRoundEventHandlers.cs
+++ b/Smod2/Smod2/EventSystem/EventHandlers/ServerRoundEventHandlers.cs
@@ -42,6 +42,14 @@ namespace Smod2.EventHandlers
 		void OnLateDisconnect(LateDisconnectEvent ev);
 	}
 
+	public interface IEventHandlerPlayerLeave : IEventHandler
+	{
+		/// <summary>  
+		///  This is called when OnDestroy() is called on QueryProcessor.
+		/// </summary> 
+		void OnPlayerLeave(PlayerLeaveEvent ev);
+	}
+
 	public interface IEventHandlerCheckRoundEnd : IEventHandler
 	{
 		/// <summary>  

--- a/Smod2/Smod2/EventSystem/Events/EnvironmentEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/EnvironmentEvents.cs
@@ -1,4 +1,4 @@
-﻿using Smod2.API;
+using Smod2.API;
 using Smod2.EventHandlers;
 
 namespace Smod2.Events
@@ -168,6 +168,46 @@ namespace Smod2.Events
 		public override void ExecuteHandler(IEventHandler handler)
 		{
 			((IEventHandlerScpDeathAnnouncement)handler).OnScpDeathAnnouncement(this);
+		}
+	}
+
+	public class CassieCustomAnnouncementEvent : Event
+	{
+		public string Words { get; set; }
+		public bool MakeHold { get; set; }
+		public bool Allow { get; set; }
+
+		public CassieCustomAnnouncementEvent(string words, bool makehold, bool allow = true)
+		{
+			this.Words = words;
+			this.MakeHold = makehold;
+			this.Allow = allow;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandlerCassieCustomAnnouncement)handler).OnCassieCustomAnnouncement(this);
+		}
+	}
+
+	public class CassieTeamAnnouncementEvent : Event
+	{
+		public char NatoLetter { get; set; }
+		public int NatoNumber { get; set; }
+		public int SCPsLeft { get; set; }
+		public bool Allow { get; set; }
+
+		public CassieTeamAnnouncementEvent(char natoLetter, int natoNumber, int scpsLeft, bool allow = true)
+		{
+			this.NatoLetter = natoLetter;
+			this.NatoNumber = NatoNumber;
+			this.SCPsLeft = scpsLeft;
+			this.Allow = allow;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandlerCassieTeamAnnouncement)handler).OnCassieTeamAnnouncement(this);
 		}
 	}
 }

--- a/Smod2/Smod2/EventSystem/Events/EnvironmentEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/EnvironmentEvents.cs
@@ -174,13 +174,13 @@ namespace Smod2.Events
 	public class CassieCustomAnnouncementEvent : Event
 	{
 		public string Words { get; set; }
-		public bool MakeHold { get; set; }
+		public bool MonoSpaced { get; set; }
 		public bool Allow { get; set; }
 
-		public CassieCustomAnnouncementEvent(string words, bool makehold, bool allow = true)
+		public CassieCustomAnnouncementEvent(string words, bool monospaced, bool allow = true)
 		{
 			this.Words = words;
-			this.MakeHold = makehold;
+			this.MonoSpaced = monospaced;
 			this.Allow = allow;
 		}
 
@@ -200,7 +200,7 @@ namespace Smod2.Events
 		public CassieTeamAnnouncementEvent(char natoLetter, int natoNumber, int scpsLeft, bool allow = true)
 		{
 			this.NatoLetter = natoLetter;
-			this.NatoNumber = NatoNumber;
+			this.NatoNumber = natoNumber;
 			this.SCPsLeft = scpsLeft;
 			this.Allow = allow;
 		}

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -453,16 +453,16 @@ namespace Smod2.Events
 	public class PlayerShootEvent : PlayerEvent
 	{
 		public Player Target { get; }
-		public DamageType Weapon { get; }
+		public Weapon Weapon { get; }
 		public bool ShouldSpawnHitmarker { get; set; }
 		public bool ShouldSpawnBloodDecal { get; set; }
 		public Vector SourcePosition { get; }
 		public Vector TargetPosition { get; }
 		public string TargetHitbox { get; }
-		public WeaponType? WeaponSound { get; set; }
 		public Vector Direction { get; set; }
+		public WeaponSound WeaponSound { get; set; }
 
-		public PlayerShootEvent(Player player, Player target, DamageType weapon, Vector sourcePosition, Vector targetPosition, string targetHitbox, WeaponType weaponSound, Vector direction, bool spawnHitmarker = true, bool spawnBloodDecal = true) : base(player)
+		public PlayerShootEvent(Player player, Player target, Weapon weapon, WeaponSound weaponSound, Vector sourcePosition, Vector targetPosition, string targetHitbox, Vector direction, bool spawnHitmarker = true, bool spawnBloodDecal = true) : base(player)
 		{
 			this.Target = target;
 			this.Weapon = weapon;
@@ -471,8 +471,8 @@ namespace Smod2.Events
 			this.SourcePosition = sourcePosition;
 			this.TargetPosition = targetPosition;
 			this.TargetHitbox = targetHitbox;
-			this.WeaponSound = weaponSound;
 			this.Direction = direction;
+			this.WeaponSound = weaponSound;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -94,21 +94,6 @@ namespace Smod2.Events
 			((IEventHandlerPlayerPickupItemLate)handler).OnPlayerPickupItemLate(this);
 		}
 	}
-	public class PlayerPickupItemEarlyEvent : PlayerEvent
-	{
-		public Item Item { get; }
-		public bool Allow { get; set; }
-		public PlayerPickupItemEarlyEvent(Player player, Item item, bool allow = true) : base(player)
-		{
-			this.Item = item;
-			this.Allow = allow;
-		}
-
-		public override void ExecuteHandler(IEventHandler handler)
-		{
-			((IEventHandlerPlayerPickupItemEarly)handler).OnPlayerPickupItemEarly(this);
-		}
-	}
 
 	public class PlayerDropItemEvent : PlayerItemEvent
 	{
@@ -670,7 +655,7 @@ namespace Smod2.Events
 	{
 		public bool Allow { get; set; }
 		public GrenadeType GrenadeType { get; }
-		public Vector Position { get; }
+		public Vector Position { get; set; }
 		public PlayerGrenadeExplosion(Player thrower, GrenadeType grenadetype, Vector position, bool allow = true) : base(thrower)
 		{
 			this.Allow = allow;

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -124,12 +124,10 @@ namespace Smod2.Events
 
 	public class PlayerDropAllItemsEvent : PlayerEvent
 	{
-		public Item[] ItemsDropped { get; }
 		public bool Allow { get; set; }
 
-		public PlayerDropAllItemsEvent(Player player, Item[] ItemList, bool allow) : base(player)
+		public PlayerDropAllItemsEvent(Player player, bool allow) : base(player)
 		{
-			this.ItemsDropped = ItemList;
 			this.Allow = allow;
 		}
 

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -460,9 +460,9 @@ namespace Smod2.Events
 		public Vector TargetPosition { get; }
 		public string TargetHitbox { get; }
 		public Vector Direction { get; set; }
-		public WeaponSound WeaponSound { get; set; }
+		public WeaponSound ?WeaponSound { get; set; }
 
-		public PlayerShootEvent(Player player, Player target, Weapon weapon, WeaponSound weaponSound, Vector sourcePosition, Vector targetPosition, string targetHitbox, Vector direction, bool spawnHitmarker = true, bool spawnBloodDecal = true) : base(player)
+		public PlayerShootEvent(Player player, Player target, Weapon weapon, WeaponSound ?weaponSound, Vector sourcePosition, Vector targetPosition, string targetHitbox, Vector direction, bool spawnHitmarker = true, bool spawnBloodDecal = true) : base(player)
 		{
 			this.Target = target;
 			this.Weapon = weapon;
@@ -644,13 +644,13 @@ namespace Smod2.Events
 
 	public class PlayerReloadEvent : PlayerEvent
 	{
-		public ItemType Weapon { get; }
+		public Weapon Weapon { get; }
 		public int AmmoRemoved { get; set; }
 		public int ClipAmmoCountAfterReload { get; set; }
 		public int NormalMaxClipSize { get; }
 		public int CurrentClipAmmoCount { get; }
 		public int CurrentAmmoTotal { get; }
-		public PlayerReloadEvent(Player player, ItemType weapon, int ammoRemoved, int clipAmmoCountAfterReload, int normalMaxClipSize, int currentClipAmmoCount, int currentAmmoTotal) : base(player)
+		public PlayerReloadEvent(Player player, Weapon weapon, int ammoRemoved, int clipAmmoCountAfterReload, int normalMaxClipSize, int currentClipAmmoCount, int currentAmmoTotal) : base(player)
 		{
 			this.Weapon = weapon;
 			this.AmmoRemoved = ammoRemoved;

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -98,7 +98,7 @@ namespace Smod2.Events
 	{
 		public Item Item { get; }
 		public bool Allow { get; set; }
-		public PlayerPickupItemEarlyEvent(Player player, Item item, bool allow) : base(player)
+		public PlayerPickupItemEarlyEvent(Player player, Item item, bool allow = true) : base(player)
 		{
 			this.Item = item;
 			this.Allow = allow;
@@ -126,7 +126,7 @@ namespace Smod2.Events
 	{
 		public bool Allow { get; set; }
 
-		public PlayerDropAllItemsEvent(Player player, bool allow) : base(player)
+		public PlayerDropAllItemsEvent(Player player, bool allow = true) : base(player)
 		{
 			this.Allow = allow;
 		}
@@ -532,13 +532,13 @@ namespace Smod2.Events
 
 	public class PlayerHandcuffedEvent : PlayerEvent
 	{
-		public bool Handcuffed { get; set; }
+		public bool Allow { get; set; }
 
 		public Player Owner { get; set; }
 
-		public PlayerHandcuffedEvent(Player player, bool handcuffed, Player owner) : base(player)
+		public PlayerHandcuffedEvent(Player player, Player owner, bool allow = true) : base(player)
 		{
-			this.Handcuffed = handcuffed;
+			this.Allow = allow;
 			this.Owner = owner;
 		}
 

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -94,6 +94,21 @@ namespace Smod2.Events
 			((IEventHandlerPlayerPickupItemLate)handler).OnPlayerPickupItemLate(this);
 		}
 	}
+	public class PlayerPickupItemEarlyEvent : PlayerEvent
+	{
+		public Item Item { get; }
+		public bool Allow { get; set; }
+		public PlayerPickupItemEarlyEvent(Player player, Item item, bool allow) : base(player)
+		{
+			this.Item = item;
+			this.Allow = allow;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandlerPlayerPickupItemEarly)handler).OnPlayerPickupItemEarly(this);
+		}
+	}
 
 	public class PlayerDropItemEvent : PlayerItemEvent
 	{
@@ -104,6 +119,23 @@ namespace Smod2.Events
 		public override void ExecuteHandler(IEventHandler handler)
 		{
 			((IEventHandlerPlayerDropItem)handler).OnPlayerDropItem(this);
+		}
+	}
+
+	public class PlayerDropAllItemsEvent : PlayerEvent
+	{
+		public Item[] ItemsDropped { get; }
+		public bool Allow { get; set; }
+
+		public PlayerDropAllItemsEvent(Player player, Item[] ItemList, bool allow) : base(player)
+		{
+			this.ItemsDropped = ItemList;
+			this.Allow = allow;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandlerPlayerDropAllItems)handler).OnPlayerDropAllItems(this);
 		}
 	}
 

--- a/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -668,8 +668,14 @@ namespace Smod2.Events
 
 	public class PlayerGrenadeExplosion : PlayerEvent
 	{
-		public PlayerGrenadeExplosion(Player thrower) : base(thrower)
+		public bool Allow { get; set; }
+		public GrenadeType GrenadeType { get; }
+		public Vector Position { get; }
+		public PlayerGrenadeExplosion(Player thrower, GrenadeType grenadetype, Vector position, bool allow = true) : base(thrower)
 		{
+			this.Allow = allow;
+			this.GrenadeType = grenadetype;
+			this.Position = position;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)

--- a/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
@@ -70,8 +70,12 @@ namespace Smod2.Events
 
 	public class DisconnectEvent : ConnectionEvent
 	{
-		public DisconnectEvent(Connection connection) : base(connection)
+		public string Name { get; }
+		public string SteamID { get; }
+		public DisconnectEvent(Connection connection, string steamid, string name) : base(connection)
 		{
+			this.Name = name;
+			this.SteamID = steamid;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -82,8 +86,12 @@ namespace Smod2.Events
 
 	public class LateDisconnectEvent : ConnectionEvent
 	{
-		public LateDisconnectEvent(Connection connection) : base(connection)
+		public string Name { get; }
+		public string SteamID { get; }
+		public LateDisconnectEvent(Connection connection, string steamid, string name) : base(connection)
 		{
+			this.Name = name;
+			this.SteamID = steamid;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)

--- a/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
@@ -69,9 +69,9 @@ namespace Smod2.Events
 		}
 	}
 
-	public class DisconnectEvent : ConnectionEvent
+	public class DisconnectEvent : Event
 	{
-		public DisconnectEvent(Connection connection) : base(connection)
+		public DisconnectEvent()
 		{
 		}
 
@@ -81,9 +81,10 @@ namespace Smod2.Events
 		}
 	}
 
-	public class LateDisconnectEvent : ConnectionEvent
+
+	public class LateDisconnectEvent : Event
 	{
-		public LateDisconnectEvent(Connection connection) : base(connection)
+		public LateDisconnectEvent()
 		{
 		}
 
@@ -93,21 +94,23 @@ namespace Smod2.Events
 		}
 	}
 
-	public class OnPlayerLeaveEvent : Event
+	public class PlayerLeaveEvent : Event
 	{
 		public string Name { get; }
 		public string SteamID { get; }
 		public string IP { get; }
-		public OnPlayerLeaveEvent(string steamid, string ip, string name)
+		public int PlayerID { get; }
+		public PlayerLeaveEvent(string steamid, string ip, string name, int id)
 		{
 			this.IP = ip;
 			this.SteamID = steamid;
 			this.Name = name;
+			this.PlayerID = id;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
 		{
-			((IEventHandlerPlayerLeave)handler).OnPlayerLeave(this);
+			((IEventHandlerPlayerLeave)handler).PlayerLeaveEvent(this);
 		}
 	}
 

--- a/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
@@ -1,5 +1,6 @@
 using Smod2.API;
 using Smod2.EventHandlers;
+using System;
 
 namespace Smod2.Events
 {
@@ -92,14 +93,16 @@ namespace Smod2.Events
 		}
 	}
 
-	public class PlayerLeaveEvent : ConnectionEvent
+	public class OnPlayerLeaveEvent : Event
 	{
 		public string Name { get; }
 		public string SteamID { get; }
-		public PlayerLeaveEvent(Connection connection, string steamid, string name) : base(connection)
+		public string IP { get; }
+		public OnPlayerLeaveEvent(string steamid, string ip, string name)
 		{
-			this.Name = name;
+			this.IP = ip;
 			this.SteamID = steamid;
+			this.Name = name;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -107,7 +110,7 @@ namespace Smod2.Events
 			((IEventHandlerPlayerLeave)handler).OnPlayerLeave(this);
 		}
 	}
-	
+
 	public class CheckRoundEndEvent : ServerEvent
 	{
 		public CheckRoundEndEvent(Server server, Round round) : base(server)

--- a/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
@@ -110,7 +110,7 @@ namespace Smod2.Events
 
 		public override void ExecuteHandler(IEventHandler handler)
 		{
-			((IEventHandlerPlayerLeave)handler).PlayerLeaveEvent(this);
+			((IEventHandlerPlayerLeave)handler).OnPlayerLeave(this);
 		}
 	}
 

--- a/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
@@ -70,12 +70,8 @@ namespace Smod2.Events
 
 	public class DisconnectEvent : ConnectionEvent
 	{
-		public string Name { get; }
-		public string SteamID { get; }
-		public DisconnectEvent(Connection connection, string steamid, string name) : base(connection)
+		public DisconnectEvent(Connection connection) : base(connection)
 		{
-			this.Name = name;
-			this.SteamID = steamid;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -86,12 +82,8 @@ namespace Smod2.Events
 
 	public class LateDisconnectEvent : ConnectionEvent
 	{
-		public string Name { get; }
-		public string SteamID { get; }
-		public LateDisconnectEvent(Connection connection, string steamid, string name) : base(connection)
+		public LateDisconnectEvent(Connection connection) : base(connection)
 		{
-			this.Name = name;
-			this.SteamID = steamid;
 		}
 
 		public override void ExecuteHandler(IEventHandler handler)
@@ -100,6 +92,22 @@ namespace Smod2.Events
 		}
 	}
 
+	public class PlayerLeaveEvent : ConnectionEvent
+	{
+		public string Name { get; }
+		public string SteamID { get; }
+		public PlayerLeaveEvent(Connection connection, string steamid, string name) : base(connection)
+		{
+			this.Name = name;
+			this.SteamID = steamid;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandlerPlayerLeave)handler).OnPlayerLeave(this);
+		}
+	}
+	
 	public class CheckRoundEndEvent : ServerEvent
 	{
 		public CheckRoundEndEvent(Server server, Round round) : base(server)

--- a/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
@@ -213,5 +213,4 @@ namespace Smod2.Events
 			((IEventHandlerSetSeed)handler).OnSetSeed(this);
 		}
 	}
-	
 }

--- a/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
+++ b/Smod2/Smod2/EventSystem/Events/ServerRoundEvents.cs
@@ -1,4 +1,4 @@
-﻿using Smod2.API;
+using Smod2.API;
 using Smod2.EventHandlers;
 
 namespace Smod2.Events
@@ -198,4 +198,20 @@ namespace Smod2.Events
 			((IEventHandlerSceneChanged)handler).OnSceneChanged(this);
 		}
 	}
+	
+	public class SetSeedEvent : Event
+	{
+		public int Seed { get; set; }
+
+		public SetSeedEvent(int seed)
+		{
+			this.Seed = seed;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandlerSetSeed)handler).OnSetSeed(this);
+		}
+	}
+	
 }

--- a/Smod2/Smod2/PluginManager.cs
+++ b/Smod2/Smod2/PluginManager.cs
@@ -28,7 +28,7 @@ namespace Smod2
 		public static readonly int SMOD_MINOR = 5;
 		public static readonly int SMOD_REVISION = 1;
 
-		public static readonly string SMOD_BUILD = "H";
+		public static readonly string SMOD_BUILD = "I";
 
 		public static readonly string DEPENDENCY_FOLDER = "dependencies";
 

--- a/Smod2/Smod2/PluginManager.cs
+++ b/Smod2/Smod2/PluginManager.cs
@@ -28,7 +28,7 @@ namespace Smod2
 		public static readonly int SMOD_MINOR = 5;
 		public static readonly int SMOD_REVISION = 1;
 
-		public static readonly string SMOD_BUILD = "G";
+		public static readonly string SMOD_BUILD = "H";
 
 		public static readonly string DEPENDENCY_FOLDER = "dependencies";
 

--- a/Smod2/Smod2/PluginManager.cs
+++ b/Smod2/Smod2/PluginManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -26,7 +26,7 @@ namespace Smod2
 	{
 		public static readonly int SMOD_MAJOR = 3;
 		public static readonly int SMOD_MINOR = 5;
-		public static readonly int SMOD_REVISION = 0;
+		public static readonly int SMOD_REVISION = 1;
 
 		public static readonly string SMOD_BUILD = "A";
 

--- a/Smod2/Smod2/PluginManager.cs
+++ b/Smod2/Smod2/PluginManager.cs
@@ -28,7 +28,7 @@ namespace Smod2
 		public static readonly int SMOD_MINOR = 5;
 		public static readonly int SMOD_REVISION = 1;
 
-		public static readonly string SMOD_BUILD = "D";
+		public static readonly string SMOD_BUILD = "E";
 
 		public static readonly string DEPENDENCY_FOLDER = "dependencies";
 

--- a/Smod2/Smod2/PluginManager.cs
+++ b/Smod2/Smod2/PluginManager.cs
@@ -28,7 +28,7 @@ namespace Smod2
 		public static readonly int SMOD_MINOR = 5;
 		public static readonly int SMOD_REVISION = 1;
 
-		public static readonly string SMOD_BUILD = "C";
+		public static readonly string SMOD_BUILD = "D";
 
 		public static readonly string DEPENDENCY_FOLDER = "dependencies";
 

--- a/Smod2/Smod2/PluginManager.cs
+++ b/Smod2/Smod2/PluginManager.cs
@@ -28,7 +28,7 @@ namespace Smod2
 		public static readonly int SMOD_MINOR = 5;
 		public static readonly int SMOD_REVISION = 1;
 
-		public static readonly string SMOD_BUILD = "A";
+		public static readonly string SMOD_BUILD = "C";
 
 		public static readonly string DEPENDENCY_FOLDER = "dependencies";
 

--- a/Smod2/Smod2/PluginManager.cs
+++ b/Smod2/Smod2/PluginManager.cs
@@ -28,7 +28,7 @@ namespace Smod2
 		public static readonly int SMOD_MINOR = 5;
 		public static readonly int SMOD_REVISION = 1;
 
-		public static readonly string SMOD_BUILD = "I";
+		public static readonly string SMOD_BUILD = "K";
 
 		public static readonly string DEPENDENCY_FOLDER = "dependencies";
 

--- a/Smod2/Smod2/PluginManager.cs
+++ b/Smod2/Smod2/PluginManager.cs
@@ -28,7 +28,7 @@ namespace Smod2
 		public static readonly int SMOD_MINOR = 5;
 		public static readonly int SMOD_REVISION = 1;
 
-		public static readonly string SMOD_BUILD = "E";
+		public static readonly string SMOD_BUILD = "G";
 
 		public static readonly string DEPENDENCY_FOLDER = "dependencies";
 

--- a/Smod2/Smod2/Properties/AssemblyInfo.cs
+++ b/Smod2/Smod2/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.5.1.5")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
-[assembly: AssemblyFileVersion("3.5.1.5")]
+[assembly: AssemblyVersion("3.5.1.8")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
+[assembly: AssemblyFileVersion("3.5.1.8")]

--- a/Smod2/Smod2/Properties/AssemblyInfo.cs
+++ b/Smod2/Smod2/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.5.0.1")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
-[assembly: AssemblyFileVersion("3.5.0.1")]
+[assembly: AssemblyVersion("3.5.1.0")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
+[assembly: AssemblyFileVersion("3.5.1.0")]

--- a/Smod2/Smod2/Properties/AssemblyInfo.cs
+++ b/Smod2/Smod2/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.5.1.9")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
-[assembly: AssemblyFileVersion("3.5.1.9")]
+[assembly: AssemblyVersion("3.5.1.10")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
+[assembly: AssemblyFileVersion("3.5.1.10")]

--- a/Smod2/Smod2/Properties/AssemblyInfo.cs
+++ b/Smod2/Smod2/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.5.1.0")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
-[assembly: AssemblyFileVersion("3.5.1.0")]
+[assembly: AssemblyVersion("3.5.1.3")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
+[assembly: AssemblyFileVersion("3.5.1.3")]

--- a/Smod2/Smod2/Properties/AssemblyInfo.cs
+++ b/Smod2/Smod2/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.5.1.4")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
-[assembly: AssemblyFileVersion("3.5.1.4")]
+[assembly: AssemblyVersion("3.5.1.5")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
+[assembly: AssemblyFileVersion("3.5.1.5")]

--- a/Smod2/Smod2/Properties/AssemblyInfo.cs
+++ b/Smod2/Smod2/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.5.1.10")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
-[assembly: AssemblyFileVersion("3.5.1.10")]
+[assembly: AssemblyVersion("3.5.1.11")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
+[assembly: AssemblyFileVersion("3.5.1.11")]

--- a/Smod2/Smod2/Properties/AssemblyInfo.cs
+++ b/Smod2/Smod2/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.5.1.8")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
-[assembly: AssemblyFileVersion("3.5.1.8")]
+[assembly: AssemblyVersion("3.5.1.9")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
+[assembly: AssemblyFileVersion("3.5.1.9")]

--- a/Smod2/Smod2/Properties/AssemblyInfo.cs
+++ b/Smod2/Smod2/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.5.1.3")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
-[assembly: AssemblyFileVersion("3.5.1.3")]
+[assembly: AssemblyVersion("3.5.1.4")] //Just imagine the last character is the equivalent letter because otherwise it gets angry
+[assembly: AssemblyFileVersion("3.5.1.4")]

--- a/Smod2/Smod2/Smod2.csproj
+++ b/Smod2/Smod2/Smod2.csproj
@@ -44,6 +44,7 @@
     <Compile Include="API\Map.cs" />
     <Compile Include="API\UserGroup.cs" />
     <Compile Include="API\Vector.cs" />
+    <Compile Include="API\Weapon.cs" />
     <Compile Include="Config\ConfigOption.cs" />
     <Compile Include="Config\LiveConfig.cs" />
     <Compile Include="LangManager\LangOption.cs" />


### PR DESCRIPTION
- Added/modified events
  - Added `PlayerDropAllItemsEvent`. Called when a player's items are going to be dropped.
  - Added `CassieCustomAnnouncementEvent`. Called when a custom announcement is made. (AKA through the api for example.)
  - Added `CassieTeamAnnouncementEvent`. Called when NTF respawns.
  - Added `OnSetSeed`. Called after the seed is being decided.
  - Added `PlayerLeaveEvent` which has SteamID, IP, Nickname and PlayerID and is fired as QueryProcessor is being destroyed. 
  - Removed `SmodConnection` from `DisconnectEvent` & `LateDisconnectEvent`. ```These are API breaking changes``` (Neither had access to the information anyways)
  - Deprecated `LateDisconnectEvent` in favor of `PlayerLeaveEvent`
  - `PlayerShootEvent` changed to return `SmodWeapon` and `WeaponSound` instead of `DamageType` and `WeaponType` (Other variables are still there)
  - `PlayerReloadEvent` now returns SmodWeapon instead of Itemtype.
  - `PlayerGrenadeExplosion` now has GrenadeType, Position and Allow and moved the event to right before the grenade explodes and sends that explosion info to clients.
  - `PlayerPickupItemEvent` changed to when item is still on ground and now setting Allow to false leaves it on the ground.

- Added 2 new bool properties to SmodPlayer
  - `Muted` - Get and Set of CharacterClassManager `NetworkMuted`
  - `IntercomMuted` - Get and Set of CharacterClassManager `NetworkIntercomMuted`

Added new weapon class.
- This is done by converting smod item to smod weapon
   - `AmmoInClip`
   - `AmmoType`
   - `Sight`
   - `Barrel`
   - `Other`
   - `MaxClipSize`
   - `DamageType`
   - `ToItem()` Coverts SmodWeapon to SmodItem for events that return SmodWeapon.
 - Added new enums
   - `WeaponSight` All possible weapon sights.
   - `WeaponBarrel` All possible weapon barrels.
   - `WeaponOther` All possible weapon others.
   - `WeaponType` All weapons supported (COM15, Micro, E11, P90, MP4, Logicer and USP.)
   - `WeaponSound` All weapons that have sounds that be can be heard by a player. (Used in the ShootEvent and is equal in index to Weapon array in WeaponManager)
 - Added 2 methods to SmodItem
   - `ToWeapon()` Returns SModWeapon if item is a weapon otherwise it returns null.
   - `IsWeapon` Bool to check if item is supported weapon.

 - Added 2 new overloads to SpawnItem
   - Allows you to spawn weapon with ammo and set it's attachments.
   - Allows you to spawn ammoboxes with ammo.

 - Fixed `PlayerHandcuffedEvent` event.

 - Added new boolean config options. 
   - `nuke_operational_during_decon` Allows players to interact with the nuke during LightZone decontamination, default false.
   - `mtf_respawn_nukecountdown` Allows MTF/CI to respawn during nuke countdown, default false.
   - `mtf_respawn_decontamination` Allows MTF/CI to respawn during LightZone decontamination, default false.
   - `ci_allow_post_nuke_respawn` Default False.
   - `ignore_tutorial_anticheat` Default False.
   - `096_destroy_locked_doors` Default True.

- Misc changes
  - Removed `disable_handcuff_event` config because the event works fine now.
  - Tesla gate is no longer getting config int list every fixed update.
  - No longer getting bool config every time it sends debug message.
  - `MP4` in ItemType renamed to `MP7`.
  - `window_health` config works now.
  - Players should no longer trigger antispeedhack while going through destroyed doors.
  - Added  GetPlayers(Predicate<Player> predicate).
  - `scp049-2_hp` changed to `scp049_2_hp`. 
  - GetBypassMode() changed to BypassMode property (get & set)

Updated version to 3.5.1-K